### PR TITLE
delete unnecessary 'return err'

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -44,9 +44,6 @@ func RunCommand(
 			return err
 		}
 		formatter = factory.NewDefault()
-		if err != nil {
-			return err
-		}
 	} else {
 		fType, ok := config.FormatterConfig["type"].(string)
 		if !ok {


### PR DESCRIPTION
I deleted unnecessary `return err`.  
`factory.NewDefault()`  func doesn't have `err` returned value.