### PR TITLE
ci: Fix main build path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,10 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - env:
+  - id: yamlfmt 
+    main: ./cmd/yamlfmt
+    binary: yamlfmt
+    env:
       - CGO_ENABLED=0
     goos:
       - linux


### PR DESCRIPTION
Forgot to adjust the `yamlfmt` command build to use the path to the
command; by default it looks for a main function in the root of the repo
which I don't have.