### PR TITLE
Nix support for reproductive build

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+use flake

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+flake.lock linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .yamlfmt
+
+# Nix
+.direnv
+result
+
+# VSCode
+.vscode/settings.json

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,1 @@
+exclude = ["gomod2nix.toml"]

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+(
+  import
+  (
+    fetchTarball
+    (with (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat.locked; {
+      url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+      sha256 = narHash;
+    })
+  )
+  {src = ./.;}
+)
+.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,179 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1660811669,
+        "narHash": "sha256-V6lmsaLNFz41myppL0yxglta92ijkSvpZ+XVygAh+bU=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "c2feacb46ee69949124c835419861143c4016fb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1660721781,
+        "narHash": "sha256-7skn4VUVzxqgH6kU7juBlARQ4Ts+qQ4Lq48xU87x8xI=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "b8c2216317cd23e4f49f1235c27522604be60349",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1661179195,
+        "narHash": "sha256-1tM5Xu5FhLPZ2JaYIyQYsE7Ixg/GgBJK4bpjONhFcD8=",
+        "owner": "ilkecan",
+        "repo": "nix-filter",
+        "rev": "7fdfe95ab431e27d53aaf33007bbf81019544e4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ilkecan",
+        "ref": "add-_assertPathIsDirectory",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643381941,
+        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1661193147,
+        "narHash": "sha256-qnXyjH8Pk1SZ+b32AeU/KGZPgQCKLIM2ZCT0tjLGrpI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "568b598a9a86f9107e754672b373038db53e4bdc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1660998696,
+        "narHash": "sha256-N5eDv9THZz5pFn7NR1swaFrAJYByfrA5gU5L7JONItA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13711c9ab9f5a160a44affb7a6221be53318a873",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "gomod2nix": "gomod2nix",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "A basic gomod2nix flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    gomod2nix.url = "github:tweag/gomod2nix";
+
+    # dev
+    nix-filter.url = "github:ilkecan/nix-filter/add-_assertPathIsDirectory";
+    devshell.url = "github:numtide/devshell";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = {
+    self,
+    nix-filter,
+    flake-utils,
+    ...
+  } @ inputs: (
+    flake-utils.lib.eachDefaultSystem
+    (system: let
+      inherit (pkgs) lib;
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          inputs.gomod2nix.overlays.default
+          inputs.devshell.overlay
+        ];
+      };
+    in {
+      packages.yamlfmt = pkgs.buildGoApplication {
+        pname = "yamlfmt";
+        version = "0.0.1";
+        src = with nix-filter.lib;
+          filter {
+            root = ./.;
+            include = [
+              "go.mod"
+              "go.sum"
+              "gomod2nix.toml"
+              "yamlfmt.go"
+              "cmd"
+              "command"
+              "engine"
+              "formatters"
+            ];
+          };
+        modules = ./gomod2nix.toml;
+      };
+      packages.default = self.packages.${system}.yamlfmt;
+
+      apps.yamlfmt = flake-utils.lib.mkApp {
+        drv = self.packages.${system}.yamlfmt;
+        name = "yamlfmt";
+      };
+      apps.default = self.apps.${system}.yamlfmt;
+
+      devShells.default = pkgs.devshell.mkShell {
+        packages = with pkgs; [
+          (mkGoEnv {pwd = ./.;})
+          gomod2nix
+          golangci-lint
+          alejandra
+          taplo-cli
+          treefmt
+          self.packages.${system}.yamlfmt
+        ];
+      };
+    })
+  );
+}

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,15 @@
+schema = 3
+
+[mod]
+  [mod."github.com/bmatcuk/doublestar/v4"]
+    version = "v4.2.0"
+    hash = "sha256-7xnw1NxJQhpCrOiWOxIgpztSFAgsRJu2w1xlbRR3Tac="
+  [mod."github.com/google/go-cmp"]
+    version = "v0.5.8"
+    hash = "sha256-8zkIo+Sr1NXMnj3PNmvjX2sZKnAKWXOFvmnX7D9bwxQ="
+  [mod."github.com/mitchellh/mapstructure"]
+    version = "v1.5.0"
+    hash = "sha256-ztVhGQXs67MF8UadVvG72G3ly0ypQW0IRDdOOkjYwoE="
+  [mod."gopkg.in/yaml.v2"]
+    version = "v2.4.0"
+    hash = "sha256-uVEGglIedjOIGZzHW4YwN1VoRSTK8o0eGZqzd+TNdd0="

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball (with lock.nodes.flake-compat.locked; {
+        url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+        sha256 = narHash;
+      })
+  )
+  {
+    src = ./.;
+  })
+.shellNix

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,13 @@
+[formatter.alejandra]
+command = "alejandra"
+includes = ["*.nix"]
+
+[formatter.taplo]
+command = "taplo"
+options = ["fmt"]
+includes = ["*.toml"]
+excludes = ["gomod2nix.toml"]
+
+[formatter.yamlfmt]
+command = "yamlfmt"
+includes = ["*.yml", "*.yaml"]


### PR DESCRIPTION
Mostly for my own convenience, I have added some files for more reproductive builds by Nix. When the time is ready, I will add this formatter to the official [Nix package repository](https://github.com/NixOS/nixpkgs), because there are very few formatters for yaml in the world.