### PR TITLE
docs: clarify maintainer

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,7 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - id: yamlfmt 
+  - id: yamlfmt
     main: ./cmd/yamlfmt
     binary: yamlfmt
     env:

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ The CLI supports 3 operation modes:
     - Format the matched files and output the diff to `stdout`, exits with status 1 if there are any differences
 
 (NOTE: If providing paths as command line arguments, the flags must be specified before any paths)
+
+## Maintainers
+
+This tool is not yet officially supported by Google. It is currenlty maintained solely by @braydonk.


### PR DESCRIPTION
It was not entirely clear that this is a tool maintained only by
myself at the moment, and isn't currently a wider Google product. This
section of the docs is to level expectations at this very early stage of
the project.