### PR TITLE
command: add support for formatting from stdin

### DIFF
--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -32,6 +32,7 @@ var (
 source yaml and formatted yaml.`)
 	dry *bool = flag.Bool("dry", false, `Perform a dry run; show the output of a formatting
 operation without performing it.`)
+	in *bool = flag.Bool("in", false, "Format yaml read from stdin and output to stdout")
 )
 
 const defaultConfigName = ".yamlfmt"
@@ -50,6 +51,8 @@ func run() error {
 		op = command.OperationLint
 	} else if *dry {
 		op = command.OperationDry
+	} else if *in {
+		op = command.OperationStdin
 	} else {
 		op = command.OperationFormat
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -15,7 +15,10 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/google/yamlfmt"
 	"github.com/google/yamlfmt/engine"
@@ -28,6 +31,7 @@ const (
 	OperationFormat Operation = iota
 	OperationLint
 	OperationDry
+	OperationStdin
 )
 
 type formatterConfig struct {
@@ -109,7 +113,34 @@ func RunCommand(
 			return err
 		}
 		fmt.Println(out)
+	case OperationStdin:
+		stdinYaml, err := readFromStdin()
+		if err != nil {
+			return err
+		}
+		out, err := engine.Formatter.Format(stdinYaml)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
 	}
 
 	return nil
+}
+
+func readFromStdin() ([]byte, error) {
+	stdin := bufio.NewReader(os.Stdin)
+	data := []byte{}
+	for {
+		b, err := stdin.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return nil, err
+			}
+		}
+		data = append(data, b)
+	}
+	return data, nil
 }


### PR DESCRIPTION
closes #8 

This adds support for formatting yaml passed in from stdin. This enables
yaml to be piped in, and the formatted result will be output back to
stdout.