### PR TITLE
basic: Support formatting multi-document files

### DIFF
--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -53,3 +53,19 @@ a:`
 		t.Fatalf("keys were reordered:\n%s", s)
 	}
 }
+
+func TestFormatterParsesMultipleDocuments(t *testing.T) {
+	f := &basic.BasicFormatter{Config: basic.DefaultConfig()}
+
+	yaml := `b:
+---
+a:
+`
+	s, err := f.Format([]byte(yaml))
+	if err != nil {
+		t.Fatalf("expected formatting to pass, returned error: %v", err)
+	}
+	if len(s) != len([]byte(yaml)) {
+		t.Fatalf("expected yaml not to change, result: %s", string(s))
+	}
+}


### PR DESCRIPTION
Closes #14 

Files with multiple documents are more common than I originally thought,
so it is best that I switch to Decode and Encode for this formatter that
will properly format all documents in multi-document files.