### PR TITLE
basic: add include_document_start

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -61,15 +61,15 @@ func (e *Engine) FormatFile(path string) error {
 	return err
 }
 
-func (f *Engine) LintAllFiles() error {
-	paths, err := CollectPathsToFormat(f.Include, f.Exclude)
+func (e *Engine) LintAllFiles() error {
+	paths, err := CollectPathsToFormat(e.Include, e.Exclude)
 	if err != nil {
 		return err
 	}
 
 	lintErrors := NewLintFileErrors()
 	for _, path := range paths {
-		err := f.LintFile(path)
+		err := e.LintFile(path)
 		if err != nil {
 			lintErrors.Add(path, err)
 		}
@@ -97,8 +97,8 @@ func (e *Engine) LintFile(path string) error {
 	return nil
 }
 
-func (f *Engine) DryRunAllFiles() (string, error) {
-	paths, err := CollectPathsToFormat(f.Include, f.Exclude)
+func (e *Engine) DryRunAllFiles() (string, error) {
+	paths, err := CollectPathsToFormat(e.Include, e.Exclude)
 	if err != nil {
 		return "", err
 	}
@@ -106,7 +106,7 @@ func (f *Engine) DryRunAllFiles() (string, error) {
 	formatErrors := NewFormatFileErrors()
 	dryRunDiffs := NewDryRunDiffs()
 	for _, path := range paths {
-		diff, err := f.DryRunFile(path)
+		diff, err := e.DryRunFile(path)
 		if err != nil {
 			formatErrors.Add(path, err)
 		} else if diff != "" {

--- a/formatters/basic/README.md
+++ b/formatters/basic/README.md
@@ -4,6 +4,7 @@ The basic formatter is a barebones formatter that simply takes the data provided
 
 ## Configuration
 
-| Key           | Default | Description |
-|:--------------|:--------|:------------|
-| `indentation` | 2       | The indentation level in spaces to use for the formatted yaml|
+| Key                      | Default | Description |
+|:-------------------------|:--------|:------------|
+| `indentation`            | 2       | The indentation level in spaces to use for the formatted yaml|
+| `include_document_start` | false   | Include `---` at document start |

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -15,7 +15,8 @@
 package basic
 
 type Config struct {
-	Indent int `mapstructure:"indent"`
+	Indent               int  `mapstructure:"indent"`
+	IncludeDocumentStart bool `mapstructure:"include_document_start"`
 }
 
 func DefaultConfig() *Config {

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -57,5 +57,13 @@ func (f *BasicFormatter) Format(yamlContent []byte) ([]byte, error) {
 		}
 	}
 
+	if f.Config.IncludeDocumentStart {
+		return withDocumentStart(b.Bytes()), nil
+	}
 	return b.Bytes(), nil
+}
+
+func withDocumentStart(document []byte) []byte {
+	documentStart := "---\n"
+	return append([]byte(documentStart), document...)
 }

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -69,3 +69,17 @@ a:
 		t.Fatalf("expected yaml not to change, result: %s", string(s))
 	}
 }
+
+func TestWithDocumentStart(t *testing.T) {
+	f := &basic.BasicFormatter{Config: basic.DefaultConfig()}
+	f.Config.IncludeDocumentStart = true
+
+	yaml := "a:"
+	s, err := f.Format([]byte(yaml))
+	if err != nil {
+		t.Fatalf("expected formatting to pass, returned error: %v", err)
+	}
+	if strings.Index(string(s), "---\n") != 0 {
+		t.Fatalf("expected document start to be included, result was: %s", string(s))
+	}
+}


### PR DESCRIPTION
The yaml.v3 library Encoder does not include the --- at the start of
yaml files, however that is a pretty common pattern. Provide users the
option to include it if they would like.