### PR TITLE
engine: fix exclude path bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Go test
 
 on:

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/yamlfmt"
 	"github.com/google/yamlfmt/internal/diff"
+	"github.com/google/yamlfmt/internal/paths"
 )
 
 type Engine struct {
@@ -29,7 +30,7 @@ type Engine struct {
 }
 
 func (e *Engine) FormatAllFiles() error {
-	paths, err := CollectPathsToFormat(e.Include, e.Exclude)
+	paths, err := paths.CollectPathsToFormat(e.Include, e.Exclude)
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func (e *Engine) FormatFile(path string) error {
 }
 
 func (e *Engine) LintAllFiles() error {
-	paths, err := CollectPathsToFormat(e.Include, e.Exclude)
+	paths, err := paths.CollectPathsToFormat(e.Include, e.Exclude)
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func (e *Engine) LintFile(path string) error {
 }
 
 func (e *Engine) DryRunAllFiles() (string, error) {
-	paths, err := CollectPathsToFormat(e.Include, e.Exclude)
+	paths, err := paths.CollectPathsToFormat(e.Include, e.Exclude)
 	if err != nil {
 		return "", err
 	}

--- a/engine/util.go
+++ b/engine/util.go
@@ -14,60 +14,7 @@
 
 package engine
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/bmatcuk/doublestar/v4"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-)
-
-func CollectPathsToFormat(include, exclude []string) ([]string, error) {
-	includedPaths := []string{}
-	for _, pattern := range include {
-		globMatches, err := doublestar.FilepathGlob(pattern)
-		if err != nil {
-			return nil, err
-		}
-		includedPaths = append(includedPaths, globMatches...)
-	}
-
-	pathsToFormatSet := map[string]struct{}{}
-	for _, path := range includedPaths {
-		if len(exclude) == 0 {
-			pathsToFormatSet[path] = struct{}{}
-			continue
-		}
-		excluded := false
-		for _, pattern := range exclude {
-			match, err := doublestar.Match(pattern, path)
-			if err != nil {
-				return nil, err
-			}
-			if match {
-				excluded = true
-			}
-		}
-		if !excluded {
-			pathsToFormatSet[path] = struct{}{}
-		}
-	}
-	pathsToFormat := []string{}
-	for path := range pathsToFormatSet {
-		pathsToFormat = append(pathsToFormat, path)
-	}
-	return pathsToFormat, nil
-}
-
-func MultilineStringDiff(a, b string) string {
-	return cmp.Diff(
-		a, b,
-		cmpopts.AcyclicTransformer("multiline", func(s string) []string {
-			return strings.Split(s, "\n")
-		}),
-	)
-}
+import "fmt"
 
 type DryRunDiffs struct {
 	diffs map[string]string

--- a/engine/util.go
+++ b/engine/util.go
@@ -39,14 +39,18 @@ func CollectPathsToFormat(include, exclude []string) ([]string, error) {
 			pathsToFormatSet[path] = struct{}{}
 			continue
 		}
+		excluded := false
 		for _, pattern := range exclude {
 			match, err := doublestar.Match(pattern, path)
 			if err != nil {
 				return nil, err
 			}
-			if !match {
-				pathsToFormatSet[path] = struct{}{}
+			if match {
+				excluded = true
 			}
+		}
+		if !excluded {
+			pathsToFormatSet[path] = struct{}{}
 		}
 	}
 	pathsToFormat := []string{}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,56 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paths
+
+import (
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+func CollectPathsToFormat(include, exclude []string) ([]string, error) {
+	includedPaths := []string{}
+	for _, pattern := range include {
+		globMatches, err := doublestar.FilepathGlob(pattern)
+		if err != nil {
+			return nil, err
+		}
+		includedPaths = append(includedPaths, globMatches...)
+	}
+
+	pathsToFormatSet := map[string]struct{}{}
+	for _, path := range includedPaths {
+		if len(exclude) == 0 {
+			pathsToFormatSet[path] = struct{}{}
+			continue
+		}
+		excluded := false
+		for _, pattern := range exclude {
+			match, err := doublestar.Match(pattern, path)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				excluded = true
+			}
+		}
+		if !excluded {
+			pathsToFormatSet[path] = struct{}{}
+		}
+	}
+	pathsToFormat := []string{}
+	for path := range pathsToFormatSet {
+		pathsToFormat = append(pathsToFormat, path)
+	}
+	return pathsToFormat, nil
+}


### PR DESCRIPTION
If there was more than one exclude path, then every path would always be
included due to an uncaught logic bug.