### PR TITLE
chore: fix indent typo in configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In your `.yamlfmt` file you can also specify configuration for the formatter if 
 ```yaml
 formatter:
   type: basic
-  indentation: 4
+  indent: 4
 ```
 If the type is not specified, the default formatter will be used. In the tool included in this repo, the default is the [basic formatter](formatters/basic).
 

--- a/formatters/basic/README.md
+++ b/formatters/basic/README.md
@@ -6,5 +6,5 @@ The basic formatter is a barebones formatter that simply takes the data provided
 
 | Key                      | Default | Description |
 |:-------------------------|:--------|:------------|
-| `indentation`            | 2       | The indentation level in spaces to use for the formatted yaml|
+| `indent`                 | 2       | The indentation level in spaces to use for the formatted yaml|
 | `include_document_start` | false   | Include `---` at document start |


### PR DESCRIPTION
`indent` configuration option should be used instead of `indentation` as stated in the docs.