### PR TITLE
feat: accept - or /dev/stdin instead of -in

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The CLI supports 3 operation modes:
     - Format the matched files and output the diff to `stdout`
 * Lint (`-lint` flag)
     - Format the matched files and output the diff to `stdout`, exits with status 1 if there are any differences
-* Stdin (`-in` flag)
+* Stdin (just `-` or `/dev/stdin` argument)
     - Format the yaml data from `stdin` and output the result to `stdout`
 
 (NOTE: If providing paths as command line arguments, the flags must be specified before any paths)

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -32,7 +32,6 @@ var (
 source yaml and formatted yaml.`)
 	dry *bool = flag.Bool("dry", false, `Perform a dry run; show the output of a formatting
 operation without performing it.`)
-	in *bool = flag.Bool("in", false, "Format yaml read from stdin and output to stdout")
 )
 
 const defaultConfigName = ".yamlfmt"
@@ -51,10 +50,12 @@ func run() error {
 		op = command.OperationLint
 	} else if *dry {
 		op = command.OperationDry
-	} else if *in {
-		op = command.OperationStdin
 	} else {
 		op = command.OperationFormat
+	}
+
+	if len(flag.Args()) == 1 && isStdin(flag.Args()[0]) {
+		op = command.OperationStdin
 	}
 
 	configData, err := readDefaultConfigFile()
@@ -100,4 +101,8 @@ func readConfig(path string) (map[string]interface{}, error) {
 
 func getFullRegistry() *yamlfmt.Registry {
 	return yamlfmt.NewFormatterRegistry(&basic.BasicFormatterFactory{})
+}
+
+func isStdin(arg string) bool {
+	return arg == "-" || arg == "/dev/stdin"
 }


### PR DESCRIPTION
closes #26 

Most command line utilities handle stdin with the `-` or `/dev/stdin`
argument. This PR changes the stdin operation detection from `-in` to
`-` or `/dev/stdin`. This detection is done manually to keep behaviour
consistent across platforms.