### PR TITLE
feat: add ability to pass config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ If the type is not specified, the default formatter will be used. In the tool in
 The CLI supports the following flags/arguments:
 
 * Format (default, no flags)
-  - Format and write the matched files
+	- Format and write the matched files
 * Dry run (`-dry` flag)
-  - Format the matched files and output the diff to `stdout`
+	- Format the matched files and output the diff to `stdout`
 * Lint (`-lint` flag)
-  - Format the matched files and output the diff to `stdout`, exits with status 1 if there are any differences
+	- Format the matched files and output the diff to `stdout`, exits with status 1 if there are any differences
 * Stdin (just `-` or `/dev/stdin` argument)
-  - Format the yaml data from `stdin` and output the result to `stdout`
+	- Format the yaml data from `stdin` and output the result to `stdout`
 * Custom config path (`-conf` flag)
-  - If you would like to use a config not stored at `.yamlfmt` in the working directory, you can pass a relative or absolute path to a separate configuration file
+	- If you would like to use a config not stored at `.yamlfmt` in the working directory, you can pass a relative or absolute path to a separate configuration file
 
 
 (NOTE: If providing paths as command line arguments, the flags must be specified before any paths)

--- a/README.md
+++ b/README.md
@@ -57,15 +57,18 @@ If the type is not specified, the default formatter will be used. In the tool in
 
 ## Flags
 
-The CLI supports 3 operation modes:
+The CLI supports the following flags/arguments:
 
 * Format (default, no flags)
-    - Format and write the matched files
+  - Format and write the matched files
 * Dry run (`-dry` flag)
-    - Format the matched files and output the diff to `stdout`
+  - Format the matched files and output the diff to `stdout`
 * Lint (`-lint` flag)
-    - Format the matched files and output the diff to `stdout`, exits with status 1 if there are any differences
+  - Format the matched files and output the diff to `stdout`, exits with status 1 if there are any differences
 * Stdin (just `-` or `/dev/stdin` argument)
-    - Format the yaml data from `stdin` and output the result to `stdout`
+  - Format the yaml data from `stdin` and output the result to `stdout`
+* Custom config path (`-conf` flag)
+  - If you would like to use a config not stored at `.yamlfmt` in the working directory, you can pass a relative or absolute path to a separate configuration file
+
 
 (NOTE: If providing paths as command line arguments, the flags must be specified before any paths)


### PR DESCRIPTION
closes #29 

This PR adds a feature I originally intended for the first version but
forgot about until the opened issue. The tool now accepts a new flag
`-conf` and accepts a relative or absolute path to a config file. If the
flag is not present, it will fall back to the default config.