### PR TITLE
fix: hotfix shim for CRLF behaviour

### DIFF
--- a/formatters/basic/README.md
+++ b/formatters/basic/README.md
@@ -4,7 +4,8 @@ The basic formatter is a barebones formatter that simply takes the data provided
 
 ## Configuration
 
-| Key                      | Default | Description |
-|:-------------------------|:--------|:------------|
-| `indent`                 | 2       | The indentation level in spaces to use for the formatted yaml|
-| `include_document_start` | false   | Include `---` at document start |
+| Key                      | Type           | Default | Description |
+|:-------------------------|:---------------|:--------|:------------|
+| `indent`                 | int            | 2       | The indentation level in spaces to use for the formatted yaml|
+| `include_document_start` | bool           | false   | Include `---` at document start |
+| `line_ending`           | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings |

--- a/formatters/basic/README.md
+++ b/formatters/basic/README.md
@@ -8,4 +8,4 @@ The basic formatter is a barebones formatter that simply takes the data provided
 |:-------------------------|:---------------|:--------|:------------|
 | `indent`                 | int            | 2       | The indentation level in spaces to use for the formatted yaml|
 | `include_document_start` | bool           | false   | Include `---` at document start |
-| `line_ending`           | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings |
+| `line_ending`            | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings |

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -14,13 +14,25 @@
 
 package basic
 
+import (
+	"runtime"
+
+	"github.com/google/yamlfmt"
+)
+
 type Config struct {
-	Indent               int  `mapstructure:"indent"`
-	IncludeDocumentStart bool `mapstructure:"include_document_start"`
+	Indent               int                    `mapstructure:"indent"`
+	IncludeDocumentStart bool                   `mapstructure:"include_document_start"`
+	LineEndings          yamlfmt.LineBreakStyle `mapstructure:"line_ending"`
 }
 
 func DefaultConfig() *Config {
+	lineBreakStyle := yamlfmt.LineBreakStyleLF
+	if runtime.GOOS == "windows" {
+		lineBreakStyle = yamlfmt.LineBreakStyleCRLF
+	}
 	return &Config{
-		Indent: 2,
+		Indent:      2,
+		LineEndings: lineBreakStyle,
 	}
 }

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -21,9 +21,9 @@ import (
 )
 
 type Config struct {
-	Indent               int                    `mapstructure:"indent"`
-	IncludeDocumentStart bool                   `mapstructure:"include_document_start"`
-	LineEndings          yamlfmt.LineBreakStyle `mapstructure:"line_ending"`
+	Indent               int    `mapstructure:"indent"`
+	IncludeDocumentStart bool   `mapstructure:"include_document_start"`
+	LineEnding           string `mapstructure:"line_ending"`
 }
 
 func DefaultConfig() *Config {
@@ -32,7 +32,7 @@ func DefaultConfig() *Config {
 		lineBreakStyle = yamlfmt.LineBreakStyleCRLF
 	}
 	return &Config{
-		Indent:      2,
-		LineEndings: lineBreakStyle,
+		Indent:     2,
+		LineEnding: lineBreakStyle,
 	}
 }

--- a/formatters/basic/factory.go
+++ b/formatters/basic/factory.go
@@ -15,8 +15,6 @@
 package basic
 
 import (
-	"fmt"
-
 	"github.com/google/yamlfmt"
 	"github.com/mitchellh/mapstructure"
 )
@@ -37,6 +35,5 @@ func (f *BasicFormatterFactory) NewWithConfig(configData map[string]interface{})
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(config.LineEnding)
 	return &BasicFormatter{Config: config}, nil
 }

--- a/formatters/basic/factory.go
+++ b/formatters/basic/factory.go
@@ -15,6 +15,8 @@
 package basic
 
 import (
+	"fmt"
+
 	"github.com/google/yamlfmt"
 	"github.com/mitchellh/mapstructure"
 )
@@ -35,5 +37,6 @@ func (f *BasicFormatterFactory) NewWithConfig(configData map[string]interface{})
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(config.LineEnding)
 	return &BasicFormatter{Config: config}, nil
 }

--- a/formatters/basic/factory_test.go
+++ b/formatters/basic/factory_test.go
@@ -35,7 +35,7 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 			expectedConfig: basic.Config{
 				Indent:               4,
 				IncludeDocumentStart: false,
-				LineEndings:          yamlfmt.LineBreakStyleLF,
+				LineEnding:           yamlfmt.LineBreakStyleLF,
 			},
 		},
 		{
@@ -46,7 +46,7 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 			expectedConfig: basic.Config{
 				Indent:               2,
 				IncludeDocumentStart: true,
-				LineEndings:          yamlfmt.LineBreakStyleLF,
+				LineEnding:           yamlfmt.LineBreakStyleLF,
 			},
 		},
 		{
@@ -57,7 +57,7 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 			expectedConfig: basic.Config{
 				Indent:               2,
 				IncludeDocumentStart: false,
-				LineEndings:          yamlfmt.LineBreakStyleCRLF,
+				LineEnding:           yamlfmt.LineBreakStyleCRLF,
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 			expectedConfig: basic.Config{
 				Indent:               4,
 				IncludeDocumentStart: true,
-				LineEndings:          yamlfmt.LineBreakStyleCRLF,
+				LineEnding:           yamlfmt.LineBreakStyleCRLF,
 			},
 		},
 	}

--- a/formatters/basic/factory_test.go
+++ b/formatters/basic/factory_test.go
@@ -17,6 +17,7 @@ package basic_test
 import (
 	"testing"
 
+	"github.com/google/yamlfmt"
 	"github.com/google/yamlfmt/formatters/basic"
 )
 
@@ -34,6 +35,7 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 			expectedConfig: basic.Config{
 				Indent:               4,
 				IncludeDocumentStart: false,
+				LineEndings:          yamlfmt.LineBreakStyleLF,
 			},
 		},
 		{
@@ -44,6 +46,31 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 			expectedConfig: basic.Config{
 				Indent:               2,
 				IncludeDocumentStart: true,
+				LineEndings:          yamlfmt.LineBreakStyleLF,
+			},
+		},
+		{
+			name: "only line_ending style specified",
+			configMap: map[string]interface{}{
+				"line_ending": "crlf",
+			},
+			expectedConfig: basic.Config{
+				Indent:               2,
+				IncludeDocumentStart: false,
+				LineEndings:          yamlfmt.LineBreakStyleCRLF,
+			},
+		},
+		{
+			name: "all specified",
+			configMap: map[string]interface{}{
+				"indent":                 4,
+				"line_ending":            "crlf",
+				"include_document_start": true,
+			},
+			expectedConfig: basic.Config{
+				Indent:               4,
+				IncludeDocumentStart: true,
+				LineEndings:          yamlfmt.LineBreakStyleCRLF,
 			},
 		},
 	}

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -36,7 +36,7 @@ func (f *BasicFormatter) Type() string {
 
 func (f *BasicFormatter) Format(yamlContent []byte) ([]byte, error) {
 	var reader *bytes.Reader
-	if f.Config.LineEndings == yamlfmt.LineBreakStyleCRLF {
+	if f.Config.LineEnding == yamlfmt.LineBreakStyleCRLF {
 		crStrippedContent := hotfix.StripCRBytes(yamlContent)
 		reader = bytes.NewReader(crStrippedContent)
 	} else {
@@ -71,7 +71,7 @@ func (f *BasicFormatter) Format(yamlContent []byte) ([]byte, error) {
 	if f.Config.IncludeDocumentStart {
 		encodedContent = withDocumentStart(b.Bytes())
 	}
-	if f.Config.LineEndings == yamlfmt.LineBreakStyleCRLF {
+	if f.Config.LineEnding == yamlfmt.LineBreakStyleCRLF {
 		return hotfix.WriteCRLFBytes(encodedContent), nil
 	}
 	return encodedContent, nil

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/yamlfmt"
 	"github.com/google/yamlfmt/formatters/basic"
 )
 
@@ -81,5 +82,19 @@ func TestWithDocumentStart(t *testing.T) {
 	}
 	if strings.Index(string(s), "---\n") != 0 {
 		t.Fatalf("expected document start to be included, result was: %s", string(s))
+	}
+}
+
+func TestCRLFLineEnding(t *testing.T) {
+	f := &basic.BasicFormatter{Config: basic.DefaultConfig()}
+	f.Config.LineEndings = yamlfmt.LineBreakStyleCRLF
+
+	yaml := "# comment\r\na:\r\n"
+	result, err := f.Format([]byte(yaml))
+	if err != nil {
+		t.Fatalf("expected formatting to pass, returned error: %v", err)
+	}
+	if string(yaml) != string(result) {
+		t.Fatalf("didn't write CRLF properly in result: %v", result)
 	}
 }

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -87,7 +87,7 @@ func TestWithDocumentStart(t *testing.T) {
 
 func TestCRLFLineEnding(t *testing.T) {
 	f := &basic.BasicFormatter{Config: basic.DefaultConfig()}
-	f.Config.LineEndings = yamlfmt.LineBreakStyleCRLF
+	f.Config.LineEnding = yamlfmt.LineBreakStyleCRLF
 
 	yaml := "# comment\r\na:\r\n"
 	result, err := f.Format([]byte(yaml))

--- a/internal/hotfix/crlf.go
+++ b/internal/hotfix/crlf.go
@@ -1,0 +1,22 @@
+package hotfix
+
+func StripCRBytes(crlfContent []byte) []byte {
+	onlyLf := []byte{}
+	for _, b := range crlfContent {
+		if b != '\r' {
+			onlyLf = append(onlyLf, b)
+		}
+	}
+	return onlyLf
+}
+
+func WriteCRLFBytes(lfContent []byte) []byte {
+	crlfContent := []byte{}
+	for _, b := range lfContent {
+		if b == '\n' {
+			crlfContent = append(crlfContent, '\r')
+		}
+		crlfContent = append(crlfContent, b)
+	}
+	return crlfContent
+}

--- a/internal/hotfix/crlf_test.go
+++ b/internal/hotfix/crlf_test.go
@@ -1,0 +1,36 @@
+package hotfix_test
+
+import (
+	"testing"
+
+	"github.com/google/yamlfmt/internal/hotfix"
+)
+
+func TestStripCRBytes(t *testing.T) {
+	crlfContent := []byte("two\r\nlines\r\n")
+	lfContent := hotfix.StripCRBytes(crlfContent)
+	count := countByte(lfContent, '\r')
+	if count != 0 {
+		t.Fatalf("Found %d CR (decimal 13) bytes in %v", count, lfContent)
+	}
+}
+
+func TestWriteCRLF(t *testing.T) {
+	lfContent := []byte("two\nlines\n")
+	crlfContent := hotfix.WriteCRLFBytes(lfContent)
+	countCR := countByte(crlfContent, '\r')
+	countLF := countByte(crlfContent, '\n')
+	if countCR != countLF {
+		t.Fatalf("Found %d CR (decimal 13) and %d LF (decimal 10) bytes in %v", countCR, countLF, crlfContent)
+	}
+}
+
+func countByte(content []byte, searchByte byte) int {
+	count := 0
+	for _, b := range content {
+		if b == searchByte {
+			count++
+		}
+	}
+	return count
+}

--- a/yamlfmt.go
+++ b/yamlfmt.go
@@ -60,3 +60,10 @@ func (r *Registry) GetDefaultFactory() (Factory, error) {
 	}
 	return factory, nil
 }
+
+type LineBreakStyle string
+
+const (
+	LineBreakStyleLF   LineBreakStyle = "lf"
+	LineBreakStyleCRLF LineBreakStyle = "crlf"
+)

--- a/yamlfmt.go
+++ b/yamlfmt.go
@@ -61,9 +61,7 @@ func (r *Registry) GetDefaultFactory() (Factory, error) {
 	return factory, nil
 }
 
-type LineBreakStyle string
-
 const (
-	LineBreakStyleLF   LineBreakStyle = "lf"
-	LineBreakStyleCRLF LineBreakStyle = "crlf"
+	LineBreakStyleLF   = "lf"
+	LineBreakStyleCRLF = "crlf"
 )


### PR DESCRIPTION
Closes #34 

Added a configuration option for line endings, which is a feature that
needs to exist anyway. Also included temporary hotfix behaviour for CRLF
normalization while waiting for upstream fixes to get merged.