### PR TITLE
fix: line break format issue after refactor code

### DIFF
--- a/formatters/basic/features.go
+++ b/formatters/basic/features.go
@@ -54,7 +54,7 @@ func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
 		if config.LineEnding == yamlfmt.LineBreakStyleCRLF {
 			linebreakStr = "\r\n"
 		}
-		featLineBreak := hotfix.MakeFeatureRetainLineBreak(linebreakStr, config.Indent)
+		featLineBreak := hotfix.MakeFeatureRetainLineBreak(linebreakStr)
 		features = append(features, featLineBreak)
 	}
 	return features

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -175,6 +175,26 @@ shell: |
   echo "hello, world"
 `,
 		},
+		{
+			desc: "multi level nested literal string",
+			input: `a:  1
+x:
+  y:
+    shell: |
+      #!/usr/bin/env bash
+
+        # bye
+      echo "hello, world"`,
+			expect: `a: 1
+x:
+  y:
+    shell: |
+      #!/usr/bin/env bash
+
+        # bye
+      echo "hello, world"
+`,
+		},
 	}
 	config := basic.DefaultConfig()
 	config.RetainLineBreaks = true


### PR DESCRIPTION
I notice my PR for retaining line breaks got refactors. However the original [indentLen func](https://github.com/google/yamlfmt/blob/e05c99fbdf1d44bf9e2780f30fe040ad2274da19/formatters/basic/line_break.go#L62) got removed. It's required. Things got complicated when yaml contains literal multi-line string. If the indent is fixed 2, when it comes to multi-level indent string the format result will be wrong. So the `paddinger` always return the max padding for each line.

This PR fixes the refactor regression issue and explicitly add a test case.