### PR TITLE
chore: better format defaults

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -122,7 +122,7 @@ func RunCommand(
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(out))
+		fmt.Print(string(out))
 	}
 
 	return nil


### PR DESCRIPTION
Now I bundle the binary as a vscode extension. I use the stdin method to do the job and set the editor settings `formatOnSave` true. Each time saving the file, the format result will always insert a new line at the end, which is annoying.

So, this PR:

- don't append new line at the end and keep the content as it is
- default retain line breaks for readability since format itself is all about readability