### PR TITLE
Support disallowing YAML anchors and aliases

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -28,7 +28,6 @@ type Engine struct {
 	Exclude          []string
 	LineSepCharacter string
 	Formatter        yamlfmt.Formatter
-	DisallowAnchors  bool
 }
 
 func (e *Engine) FormatAllFiles() error {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -28,6 +28,7 @@ type Engine struct {
 	Exclude          []string
 	LineSepCharacter string
 	Formatter        yamlfmt.Formatter
+	DisallowAnchors  bool
 }
 
 func (e *Engine) FormatAllFiles() error {

--- a/formatters/basic/README.md
+++ b/formatters/basic/README.md
@@ -11,3 +11,4 @@ The basic formatter is a barebones formatter that simply takes the data provided
 | `line_ending`            | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings. This setting will be overwritten by the global `line_ending`. |
 | `emoji_support`          | bool           | false   | Support encoding utf-8 emojis |
 | `retain_line_breaks`     | bool           | false   | Retain line breaks in formatted yaml |
+| `disallow_anchors`       | bool           | false   | If true, reject any YAML anchors or aliases found in the document. |

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	EmojiSupport         bool                   `mapstructure:"emoji_support"`
 	LineEnding           yamlfmt.LineBreakStyle `mapstructure:"line_ending"`
 	RetainLineBreaks     bool                   `mapstructure:"retain_line_breaks"`
+	DisallowAnchors      bool                   `mapstructure:"disallow_anchors"`
 }
 
 func DefaultConfig() *Config {

--- a/formatters/basic/factory.go
+++ b/formatters/basic/factory.go
@@ -38,7 +38,8 @@ func (f *BasicFormatterFactory) NewFormatter(configData map[string]interface{}) 
 
 func newFormatter(config *Config) yamlfmt.Formatter {
 	return &BasicFormatter{
-		Config:   config,
-		Features: ConfigureFeaturesFromConfig(config),
+		Config:       config,
+		Features:     ConfigureFeaturesFromConfig(config),
+		YAMLFeatures: ConfigureYAMLFeaturesFromConfig(config),
 	}
 }

--- a/formatters/basic/features.go
+++ b/formatters/basic/features.go
@@ -16,6 +16,7 @@ package basic
 
 import (
 	"github.com/google/yamlfmt"
+	"github.com/google/yamlfmt/internal/anchors"
 	"github.com/google/yamlfmt/internal/hotfix"
 )
 
@@ -36,6 +37,10 @@ var (
 		BeforeAction: hotfix.StripCRBytes,
 		AfterAction:  hotfix.WriteCRLFBytes,
 	}
+	featDisallowAliases = yamlfmt.Feature{
+		Name:         "Disallow Anchors",
+		DuringAction: anchors.Check,
+	}
 )
 
 func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
@@ -48,6 +53,9 @@ func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
 	}
 	if config.LineEnding == yamlfmt.LineBreakStyleCRLF {
 		features = append(features, featCRLFSupport)
+	}
+	if config.DisallowAnchors {
+		features = append(features, featDisallowAliases)
 	}
 	if config.RetainLineBreaks {
 		lineSep, err := config.LineEnding.Separator()

--- a/formatters/basic/features.go
+++ b/formatters/basic/features.go
@@ -37,10 +37,6 @@ var (
 		BeforeAction: hotfix.StripCRBytes,
 		AfterAction:  hotfix.WriteCRLFBytes,
 	}
-	featDisallowAliases = yamlfmt.Feature{
-		Name:         "Disallow Anchors",
-		DuringAction: anchors.Check,
-	}
 )
 
 func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
@@ -54,9 +50,6 @@ func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
 	if config.LineEnding == yamlfmt.LineBreakStyleCRLF {
 		features = append(features, featCRLFSupport)
 	}
-	if config.DisallowAnchors {
-		features = append(features, featDisallowAliases)
-	}
 	if config.RetainLineBreaks {
 		lineSep, err := config.LineEnding.Separator()
 		if err != nil {
@@ -64,6 +57,14 @@ func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
 		}
 		featLineBreak := hotfix.MakeFeatureRetainLineBreak(lineSep)
 		features = append(features, featLineBreak)
+	}
+	return features
+}
+
+func ConfigureYAMLFeaturesFromConfig(config *Config) YAMLFeatureList {
+	var features YAMLFeatureList
+	if config.DisallowAnchors {
+		features = append(features, anchors.Check)
 	}
 	return features
 }

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -26,9 +26,23 @@ import (
 const BasicFormatterType string = "basic"
 
 type BasicFormatter struct {
-	Config   *Config
-	Features yamlfmt.FeatureList
+	Config       *Config
+	Features     yamlfmt.FeatureList
+	YAMLFeatures YAMLFeatureList
 }
+
+type YAMLFeatureList []YAMLFeatureFunc
+
+func (fl YAMLFeatureList) ApplyFeatures(node yaml.Node) error {
+	for _, f := range fl {
+		if err := f(node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type YAMLFeatureFunc func(yaml.Node) error
 
 // yamlfmt.Formatter interface
 
@@ -61,7 +75,7 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 
 	// Run all features with DuringActions.
 	for _, d := range documents {
-		if err := f.Features.ApplyYAMLFeatures(d); err != nil {
+		if err := f.YAMLFeatures.ApplyFeatures(d); err != nil {
 			return nil, err
 		}
 	}

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -31,19 +31,6 @@ type BasicFormatter struct {
 	YAMLFeatures YAMLFeatureList
 }
 
-type YAMLFeatureList []YAMLFeatureFunc
-
-func (fl YAMLFeatureList) ApplyFeatures(node yaml.Node) error {
-	for _, f := range fl {
-		if err := f(node); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type YAMLFeatureFunc func(yaml.Node) error
-
 // yamlfmt.Formatter interface
 
 func (f *BasicFormatter) Type() string {
@@ -73,7 +60,7 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 		documents = append(documents, docNode)
 	}
 
-	// Run all features with DuringActions.
+	// Run all YAML features.
 	for _, d := range documents {
 		if err := f.YAMLFeatures.ApplyFeatures(d); err != nil {
 			return nil, err
@@ -98,3 +85,16 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 
 	return resultYaml, nil
 }
+
+type YAMLFeatureList []YAMLFeatureFunc
+
+func (fl YAMLFeatureList) ApplyFeatures(node yaml.Node) error {
+	for _, f := range fl {
+		if err := f(node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type YAMLFeatureFunc func(yaml.Node) error

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -59,6 +59,13 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 		documents = append(documents, docNode)
 	}
 
+	// Run all features with DuringActions.
+	for _, d := range documents {
+		if err := f.Features.ApplyYAMLFeatures(d); err != nil {
+			return nil, err
+		}
+	}
+
 	var b bytes.Buffer
 	e := yaml.NewEncoder(&b)
 	e.SetIndent(f.Config.Indent)

--- a/internal/anchors/check.go
+++ b/internal/anchors/check.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anchors
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Check(n yaml.Node) error {
+	if n.Kind == yaml.AliasNode {
+		return errors.New("alias node found")
+	}
+	if n.Anchor != "" {
+		return fmt.Errorf("node references anchor %q", n.Anchor)
+	}
+	for _, c := range n.Content {
+		if err := Check(*c); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/anchors/check_test.go
+++ b/internal/anchors/check_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anchors_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/yamlfmt/internal/anchors"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheck(t *testing.T) {
+	for _, c := range []struct {
+		desc    string
+		in      string
+		wantErr bool
+	}{{
+		desc:    "no anchors",
+		in:      "foo: bar",
+		wantErr: false,
+	}, {
+		desc: "anchor",
+		// From https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/
+		in: `
+definitions:
+  steps:
+    - step: &build-test
+        name: Build and test
+        script:
+          - mvn package
+        artifacts:
+          - target/**
+
+pipelines:
+  branches:
+    develop:
+      - step: *build-test
+    main:
+      - step: *build-test
+`,
+		wantErr: true,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			var docNode yaml.Node
+			if err := yaml.NewDecoder(strings.NewReader(c.in)).Decode(&docNode); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if err := anchors.Check(docNode); (err != nil) != c.wantErr {
+				t.Errorf("Check() error = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}

--- a/yamlfmt.go
+++ b/yamlfmt.go
@@ -101,7 +101,6 @@ type FeatureApplyMode string
 
 var (
 	FeatureApplyBefore FeatureApplyMode = "before"
-	FeatureApplyDuring FeatureApplyMode = "during"
 	FeatureApplyAfter  FeatureApplyMode = "after"
 )
 
@@ -116,8 +115,6 @@ func (e *FeatureApplyError) Error() string {
 	switch e.mode {
 	case FeatureApplyBefore:
 		action = "Before"
-	case FeatureApplyDuring:
-		action = "During"
 	case FeatureApplyAfter:
 		action = "After"
 	}

--- a/yamlfmt.go
+++ b/yamlfmt.go
@@ -16,8 +16,6 @@ package yamlfmt
 
 import (
 	"fmt"
-
-	"gopkg.in/yaml.v3"
 )
 
 type Formatter interface {
@@ -90,12 +88,10 @@ func (s LineBreakStyle) Separator() (string, error) {
 }
 
 type FeatureFunc func([]byte) ([]byte, error)
-type YAMLFeatureFunc func(yaml.Node) error
 
 type Feature struct {
 	Name         string
 	BeforeAction FeatureFunc
-	DuringAction YAMLFeatureFunc
 	AfterAction  FeatureFunc
 }
 
@@ -157,19 +153,4 @@ func (fl FeatureList) ApplyFeatures(input []byte, mode FeatureApplyMode) ([]byte
 		}
 	}
 	return result, nil
-}
-
-func (fl FeatureList) ApplyYAMLFeatures(d yaml.Node) error {
-	for _, feature := range fl {
-		if feature.DuringAction != nil {
-			if err := feature.DuringAction(d); err != nil {
-				return &FeatureApplyError{
-					err:         err,
-					featureName: feature.Name,
-					mode:        FeatureApplyDuring,
-				}
-			}
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/google/yamlfmt/issues/51

This is a fairly rough first attempt. It adds a "during action" to compliment the before- and after-actions, which operates on the parsed YAML node instead of raw bytes.

Let me know what you think.