### PR TITLE
hotfix: stop unicode from removing backslashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+# Sometimes use these for testing
 .yamlfmt
+tmp
+
+# Goreleaser build folder
 dist/
 
+# vscode settings
 .vscode

--- a/internal/hotfix/unicode.go
+++ b/internal/hotfix/unicode.go
@@ -34,7 +34,7 @@ func ParseUnicodePoints(content []byte) ([]byte, error) {
 
 	var err error
 	for err != errEndOfBuffer {
-		if p.peek() == '\\' {
+		if p.peek() == '\\' && p.peekAhead(1) == 'U' {
 			err = p.parseUTF8CodePoint()
 			continue
 		}
@@ -49,7 +49,7 @@ func ParseUnicodePoints(content []byte) ([]byte, error) {
 type unicodeParser struct {
 	buf []byte
 	out []byte
-	pos int
+	pos uint
 }
 
 var (
@@ -59,6 +59,10 @@ var (
 
 func (p *unicodeParser) peek() byte {
 	return p.buf[p.pos]
+}
+
+func (p *unicodeParser) peekAhead(n uint) byte {
+	return p.buf[p.pos+n]
 }
 
 func (p *unicodeParser) write() {
@@ -71,7 +75,7 @@ func (p *unicodeParser) writeArbitrary(b []byte) {
 
 func (p *unicodeParser) next() error {
 	p.pos++
-	if p.pos == len(p.buf) {
+	if p.pos == uint(len(p.buf)) {
 		return errEndOfBuffer
 	}
 	return nil

--- a/internal/hotfix/unicode_test.go
+++ b/internal/hotfix/unicode_test.go
@@ -37,6 +37,11 @@ func TestParseEmoji(t *testing.T) {
 			yamlStr:     "a: 😼 👑\n",
 			expectedStr: "a: \"😼 👑\"\n",
 		},
+		{
+			name:        "retains backslashes",
+			yamlStr:     "a: \\look at my backslash\n",
+			expectedStr: "a: \\look at my backslash\n",
+		},
 	}
 
 	f := &basic.BasicFormatter{Config: basic.DefaultConfig()}


### PR DESCRIPTION
Closes #53 

Due to a logic oversight in the unicode parser, backslashes weren't being overwritten in scenarios where the backslash wasn't part of a unicode point representation. This PR changes it so the point is only parsed if it sees \ and U at once, otherwise writing the \ as normal.