### PR TITLE
feat: github actions for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Github Actions for Releases
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    strategy:
+      matrix:
+        version: ['1.19']
+    env:
+      GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.version }}
+          check-latest: true
+          cache: true
+      - name: Build and package with GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: --skip-publish
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/checksums.txt
+            dist/*.tar.gz


### PR DESCRIPTION
close #10

The action execution detail cloud be found [here](https://github.com/longkai/yamlfmt/actions/runs/3211543529) and release page [here](https://github.com/longkai/yamlfmt/releases/tag/v0.5.0)