### PR TITLE
fix: cleanup exclude patterns

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -16,6 +16,7 @@ package paths
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -38,7 +39,7 @@ func CollectPathsToFormat(include, exclude []string) ([]string, error) {
 		}
 		excluded := false
 		for _, pattern := range exclude {
-			match, err := doublestar.Match(pattern, path)
+			match, err := doublestar.Match(filepath.Clean(pattern), path)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Problem: if an exclude is prefixed with `./`, the `doublestar.Match(pattern, path)` method for matching returns false.
This patch cleans up the pattern before `Match` function and makes `./`-prefixed excludes possible.

Signed-off-by: Florian Bauer <florian@fsrv.xyz>