### PR TITLE
cmd: add support for config home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yamlfmt x.yaml y.yaml config/**/*.yaml
 
 ## Configuration
 
-The tool can be configured through a yaml configuration file. The tool looks for the config folder in the following order:
+The tool can be configured through a yaml configuration file. The tool looks for the config file in the following order:
 
 1. Specified in the `--conf` flag (if this is an invalid path or doesn't exist, the tool will fail)
 2. A `.yamlfmt` file in the current working directory

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ yamlfmt x.yaml y.yaml config/**/*.yaml
 
 ## Configuration
 
-The tool can be configured with a `.yamlfmt` configuration file in the working directory. The configuration is specified in yaml.
+The tool can be configured through a yaml configuration file. The tool looks for the config folder in the following order:
+1. Specified in the `--conf` flag (if this is an invalid path or doesn't exist, the tool will fail)
+2. A `.yamlfmt` file in the current working directory
+3. A `yamlfmt` folder with a `.yamlfmt` file in the system config directory (`$XDG_CONFIG_HOME`, `$HOME/.config`, `%LOCALAPPDATA%`) e.g. `$HOME/.config/yamlfmt/.yamlfmt`
+If none of these are found, the tool's default configuration will be used.
 
 ### Include/Exclude
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ yamlfmt x.yaml y.yaml config/**/*.yaml
 ## Configuration
 
 The tool can be configured through a yaml configuration file. The tool looks for the config folder in the following order:
+
 1. Specified in the `--conf` flag (if this is an invalid path or doesn't exist, the tool will fail)
 2. A `.yamlfmt` file in the current working directory
 3. A `yamlfmt` folder with a `.yamlfmt` file in the system config directory (`$XDG_CONFIG_HOME`, `$HOME/.config`, `%LOCALAPPDATA%`) e.g. `$HOME/.config/yamlfmt/.yamlfmt`
+
 If none of these are found, the tool's default configuration will be used.
 
 ### Include/Exclude

--- a/cmd/yamlfmt/config.go
+++ b/cmd/yamlfmt/config.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/braydonk/yaml"
+)
+
+const (
+	configFileName string = ".yamlfmt"
+	configHomeDir  string = "yamlfmt"
+)
+
+var (
+	errNoConfFlag       = errors.New("config path not specified in --conf")
+	errConfPathInvalid  = errors.New("config path specified in --conf was invalid")
+	errConfPathNotExist = errors.New("config path does not exist")
+	errConfPathIsDir    = errors.New("config path is dir")
+	errNoConfigHome     = errors.New("missing required env var for config home")
+)
+
+type configPathError struct {
+	path string
+	err  error
+}
+
+func (e *configPathError) Error() string {
+	if errors.Is(e.err, errConfPathInvalid) {
+		return fmt.Sprintf("Config path %s was invalid", e.path)
+	}
+	if errors.Is(e.err, errConfPathNotExist) {
+		return fmt.Sprintf("Config path %s does not exist", e.path)
+	}
+	if errors.Is(e.err, errConfPathIsDir) {
+		return fmt.Sprintf("Config path %s is a directory", e.path)
+	}
+	return e.err.Error()
+}
+
+func (e *configPathError) Unwrap() error {
+	return e.err
+}
+
+func readConfig(path string) (map[string]any, error) {
+	yamlBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var configData map[string]interface{}
+	err = yaml.Unmarshal(yamlBytes, &configData)
+	if err != nil {
+		return nil, err
+	}
+	return configData, nil
+}
+
+func getConfigPath() (string, error) {
+	// First priority: specified in cli flag
+	configPath, err := getConfigPathFromFlag()
+	if err != nil {
+		// If they don't provide a conf flag, we continue. If
+		// a conf flag is provided and it's wrong, we consider
+		// that a failure state.
+		if !errors.Is(err, errNoConfFlag) {
+			return "", err
+		}
+	} else {
+		return configPath, nil
+	}
+
+	// Second priority: in the working directory
+	configPath, err = getConfigPathFromWd()
+	// In this scenario, no error constitutes a failure state,
+	// so we continue to the next fallback.
+	if err == nil {
+		return configPath, nil
+	}
+
+	// Third priority: in home config directory
+	configPath, err = getConfigPathFromConfigHome()
+	// In this scenario, no error constitutes a failure state,
+	// so we continue to the next fallback.
+	if err == nil {
+		return configPath, nil
+	}
+
+	// All else fails, no path and no error (signals to
+	// use default config).
+	return "", nil
+}
+
+func getConfigPathFromFlag() (string, error) {
+	configPath := *flagConf
+	if configPath == "" {
+		return configPath, errNoConfFlag
+	}
+	return configPath, validatePath(configPath)
+}
+
+func getConfigPathFromWd() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	configPath := filepath.Join(wd, configFileName)
+	return configPath, validatePath(configPath)
+}
+
+func getConfigPathFromConfigHome() (string, error) {
+	// Build tags are a veritable pain in the behind,
+	// I'm putting both config home functions in this
+	// file. You can't stop me.
+	if runtime.GOOS == "windows" {
+		return getConfigPathFromAppDataLocal()
+	}
+	return getConfigPathFromXdgConfigHome()
+}
+
+func getConfigPathFromXdgConfigHome() (string, error) {
+	configHome, configHomePresent := os.LookupEnv("XDG_CONFIG_HOME")
+	if !configHomePresent {
+		home, homePresent := os.LookupEnv("HOME")
+		if !homePresent {
+			// I fear whom's'tever does not have a $HOME set
+			return "", errNoConfigHome
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+	homeConfigPath := filepath.Join(configHome, configHomeDir, configFileName)
+	return homeConfigPath, validatePath(homeConfigPath)
+}
+
+func getConfigPathFromAppDataLocal() (string, error) {
+	configHome, configHomePresent := os.LookupEnv("LOCALAPPDATA")
+	if !configHomePresent {
+		// I think you'd have to go out of your way to unset this,
+		// so this should only happen to sickos with broken setups.
+		return "", errNoConfigHome
+	}
+	homeConfigPath := filepath.Join(configHome, configHomeDir, configFileName)
+	return homeConfigPath, validatePath(homeConfigPath)
+}
+
+func validatePath(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &configPathError{
+				path: path,
+				err:  errConfPathNotExist,
+			}
+		}
+		if info.IsDir() {
+			return &configPathError{
+				path: path,
+				err:  errConfPathIsDir,
+			}
+		}
+		return &configPathError{
+			path: path,
+			err:  err,
+		}
+	}
+	return nil
+}

--- a/cmd/yamlfmt/flags.go
+++ b/cmd/yamlfmt/flags.go
@@ -17,8 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/google/yamlfmt/command"
 )
@@ -32,7 +30,25 @@ operation without performing it.`)
 	flagConf *string = flag.String("conf", "", "Read yamlfmt config from this path")
 )
 
-func getOperation() command.Operation {
+func configureHelp() {
+	flag.Usage = func() {
+		fmt.Println(`yamlfmt is a simple command line tool for formatting yaml files.
+
+	Arguments:
+
+	Glob paths to yaml files
+			Send any number of paths to yaml files specified in doublestar glob format (see: https://github.com/bmatcuk/doublestar). 
+			Any flags must be specified before the paths.
+
+	- or /dev/stdin
+			Passing in a single - or /dev/stdin will read the yaml from stdin and output the formatted result to stdout
+		
+	Flags:`)
+		flag.PrintDefaults()
+	}
+}
+
+func getOperationFromFlag() command.Operation {
 	if *flagIn || isStdinArg() {
 		return command.OperationStdin
 	}
@@ -51,41 +67,4 @@ func isStdinArg() bool {
 	}
 	arg := flag.Args()[0]
 	return arg == "-" || arg == "/dev/stdin"
-}
-
-func getConfigPath() (string, error) {
-	configPath := *flagConf
-	if configPath == "" {
-		configPath = defaultConfigName
-	}
-
-	if filepath.IsAbs(configPath) {
-		return configPath, nil
-	}
-
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(wd, configPath), nil
-}
-
-func configureHelp() {
-	flag.Usage = printHelpMessage
-}
-
-func printHelpMessage() {
-	fmt.Println(`yamlfmt is a simple command line tool for formatting yaml files.
-
-Arguments:
-
-  Glob paths to yaml files
-        Send any number of paths to yaml files specified in doublestar glob format (see: https://github.com/bmatcuk/doublestar). 
-        Any flags must be specified before the paths.
-
-  - or /dev/stdin
-        Passing in a single - or /dev/stdin will read the yaml from stdin and output the formatted result to stdout
-	
-Flags:`)
-	flag.PrintDefaults()
 }

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -15,18 +15,13 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"log"
-	"os"
 
-	"github.com/braydonk/yaml"
 	"github.com/google/yamlfmt"
 	"github.com/google/yamlfmt/command"
 	"github.com/google/yamlfmt/formatters/basic"
 )
-
-const defaultConfigName = ".yamlfmt"
 
 func main() {
 	if err := run(); err != nil {
@@ -38,18 +33,16 @@ func run() error {
 	configureHelp()
 	flag.Parse()
 
-	operation := getOperation()
+	operation := getOperationFromFlag()
 
+	configData := map[string]any{}
 	configPath, err := getConfigPath()
 	if err != nil {
 		return err
 	}
-
-	configData, err := readConfig(configPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			configData = map[string]interface{}{}
-		} else {
+	if configPath != "" {
+		configData, err = readConfig(configPath)
+		if err != nil {
 			return err
 		}
 	}
@@ -59,22 +52,6 @@ func run() error {
 	}
 
 	return command.RunCommand(operation, getFullRegistry(), configData)
-}
-
-func readConfig(path string) (map[string]interface{}, error) {
-	if _, err := os.Stat(path); err != nil {
-		return nil, err
-	}
-	yamlBytes, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var configData map[string]interface{}
-	err = yaml.Unmarshal(yamlBytes, &configData)
-	if err != nil {
-		return nil, err
-	}
-	return configData, nil
 }
 
 func getFullRegistry() *yamlfmt.Registry {


### PR DESCRIPTION
Closes #67 

This PR improves the config file resolution to resolve things in priority order. It also includes support for config from a configuration home directory (i.e. `$XDG_CONFIG_HOME`, `$HOME/.config`, `%LOCALAPPDATA%`) so a user can override the default config system-wide.

Signed-off-by: braydonk <braydonk@google.com>