### PR TITLE
Update yaml v3 and use new options

### DIFF
--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	LineLength           int                    `mapstructure:"max_line_length"`
 	RetainLineBreaks     bool                   `mapstructure:"retain_line_breaks"`
 	DisallowAnchors      bool                   `mapstructure:"disallow_anchors"`
+	ScanFoldedAsLiteral  bool                   `mapstructure:"scan_folded_as_literal"`
 }
 
 func DefaultConfig() *Config {

--- a/formatters/basic/features.go
+++ b/formatters/basic/features.go
@@ -20,21 +20,8 @@ import (
 	"github.com/google/yamlfmt/internal/hotfix"
 )
 
-var (
-	featIncludeDocumentStart = yamlfmt.Feature{
-		Name: "Include Document Start",
-		AfterAction: func(content []byte) ([]byte, error) {
-			documentStart := "---\n"
-			return append([]byte(documentStart), content...), nil
-		},
-	}
-)
-
 func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
 	features := []yamlfmt.Feature{}
-	if config.IncludeDocumentStart {
-		features = append(features, featIncludeDocumentStart)
-	}
 	if config.RetainLineBreaks {
 		lineSep, err := config.LineEnding.Separator()
 		if err != nil {

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -46,7 +46,7 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 
 	// Format the yaml content
 	reader := bytes.NewReader(yamlContent)
-	decoder := yaml.NewDecoder(reader)
+	decoder := f.getNewDecoder(reader)
 	documents := []yaml.Node{}
 	for {
 		var docNode yaml.Node
@@ -85,6 +85,14 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 	return resultYaml, nil
 }
 
+func (f *BasicFormatter) getNewDecoder(reader io.Reader) *yaml.Decoder {
+	d := yaml.NewDecoder(reader)
+	if f.Config.ScanFoldedAsLiteral {
+		d.SetScanBlockScalarAsLiteral(true)
+	}
+	return d
+}
+
 func (f *BasicFormatter) getNewEncoder(buf *bytes.Buffer) *yaml.Encoder {
 	e := yaml.NewEncoder(buf)
 	e.SetIndent(f.Config.Indent)
@@ -94,6 +102,9 @@ func (f *BasicFormatter) getNewEncoder(buf *bytes.Buffer) *yaml.Encoder {
 	}
 	if f.Config.IncludeDocumentStart {
 		e.SetExplicitDocumentStart()
+	}
+	if f.Config.ScanFoldedAsLiteral {
+		e.SetAssumeBlockAsLiteral(true)
 	}
 	return e
 }

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -68,12 +68,7 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 	}
 
 	var b bytes.Buffer
-	e := yaml.NewEncoder(&b)
-	e.SetIndent(f.Config.Indent)
-	e.SetWidth(f.Config.LineLength)
-	if f.Config.LineEnding == yamlfmt.LineBreakStyleCRLF {
-		e.SetLineBreakStyle(yaml.LineBreakStyleCRLF)
-	}
+	e := f.getNewEncoder(&b)
 	for _, doc := range documents {
 		err := e.Encode(&doc)
 		if err != nil {
@@ -88,6 +83,19 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 	}
 
 	return resultYaml, nil
+}
+
+func (f *BasicFormatter) getNewEncoder(buf *bytes.Buffer) *yaml.Encoder {
+	e := yaml.NewEncoder(buf)
+	e.SetIndent(f.Config.Indent)
+	e.SetWidth(f.Config.LineLength)
+	if f.Config.LineEnding == yamlfmt.LineBreakStyleCRLF {
+		e.SetLineBreakStyle(yaml.LineBreakStyleCRLF)
+	}
+	if f.Config.IncludeDocumentStart {
+		e.SetExplicitDocumentStart()
+	}
+	return e
 }
 
 type YAMLFeatureList []YAMLFeatureFunc

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -210,3 +210,24 @@ x:
 		})
 	}
 }
+
+func TestScanFoldedAsLiteral(t *testing.T) {
+	config := basic.DefaultConfig()
+	config.ScanFoldedAsLiteral = true
+	f := newFormatter(config)
+
+	yml := `a: >
+  multiline
+  folded
+  scalar`
+	lines := len(strings.Split(yml, "\n"))
+	result, err := f.Format([]byte(yml))
+	if err != nil {
+		t.Fatalf("expected formatting to pass, returned error: %v", err)
+	}
+	resultStr := string(result)
+	resultLines := len(strings.Split(resultStr, "\n"))
+	if resultLines == lines {
+		t.Fatalf("expected string to be %d lines, was %d", lines, resultLines)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/RageCage64/multilinediff v0.2.0
 	github.com/bmatcuk/doublestar/v4 v4.2.0
-	github.com/braydonk/yaml v0.2.0
+	github.com/braydonk/yaml v0.4.0
 	github.com/mitchellh/mapstructure v1.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,8 @@ github.com/RageCage64/multilinediff v0.2.0 h1:yNSpSF5NXIrmo6bRIgO4Q0g7SXqFD4j/WE
 github.com/RageCage64/multilinediff v0.2.0/go.mod h1:pKr+KLgP0gvRzA+yv0/IUaYQuBYN1ucWysvsL58aMP0=
 github.com/bmatcuk/doublestar/v4 v4.2.0 h1:Qu+u9wR3Vd89LnlLMHvnZ5coJMWKQamqdz9/p5GNthA=
 github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/braydonk/yaml v0.1.0 h1:5YHA82fwVjHNONmSwFhAMfxqyUljBRwPrrEbQv6jGdU=
-github.com/braydonk/yaml v0.1.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
-github.com/braydonk/yaml v0.2.0 h1:9vLyCMyKcPvcy8hro5otfCYMu6gmOzOU29/AE66T50A=
-github.com/braydonk/yaml v0.2.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
+github.com/braydonk/yaml v0.4.0 h1:MNjdriecuspytC31J7Tzx6O8b1yAbMSTGvRG6vLSXZc=
+github.com/braydonk/yaml v0.4.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
Closes #63
Closes #69

Updates `github.com/braydonk/yaml` to `v0.4.0` to use the new options. Adjusts the `include_document_start` option to use the library instead of a hack feature, and adds `scan_folded_as_literal` option to allow preservation of newlines in folded-style block scalars. 