### PR TITLE
pre-commit: Add pre-commit support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: yamlfmt
+  name: yamlfmt 
+  description: This hook uses github.com/google/yamlfmt to format yaml files. Requires golang >1.18 to be installed.
+  entry: yamlfmt .
+  language: golang
+  types: [yaml]


### PR DESCRIPTION
Closes #58 

This PR adds a .pre-commit-hooks.yaml file so that it can integrate with the popular `pre-commit` tool.