### PR TITLE
yamlfmt: remove a print I used for debugging

### DIFF
--- a/cmd/yamlfmt/config.go
+++ b/cmd/yamlfmt/config.go
@@ -199,9 +199,6 @@ func makeCommandConfigFromData(configData map[string]any) (*command.Config, erro
 
 	// Overwrite config if includes are provided through args
 	if len(flag.Args()) > 0 {
-		for _, x := range flag.Args() {
-			fmt.Println(x)
-		}
 		config.Include = flag.Args()
 	}
 


### PR DESCRIPTION
Closes #80 

Accidentally included a print I was using for debugging that printed all arguments specified in the path.