### PR TITLE
Fix max_line_length config default value

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -52,7 +52,7 @@ The basic formatter is a barebones formatter that simply takes the data provided
 | `line_ending`            | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings. This setting will be overwritten by the global `line_ending`. |
 | `retain_line_breaks`     | bool           | false   | Retain line breaks in formatted yaml |
 | `disallow_anchors`       | bool           | false   | If true, reject any YAML anchors or aliases found in the document. |
-| `max_line_length`        | int            | -1      | Set the maximum line length (see notes below) |
+| `max_line_length`        | int            | 0      | Set the maximum line length (see notes below). if not set, defaults to 0 which means no limit. |
 | `scan_folded_as_literal` | bool           | false   | Option that will preserve newlines in folded block scalars (blocks that start with `>`). |
 
 ## Note on `max_line_length`

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -96,7 +96,9 @@ func (f *BasicFormatter) getNewDecoder(reader io.Reader) *yaml.Decoder {
 func (f *BasicFormatter) getNewEncoder(buf *bytes.Buffer) *yaml.Encoder {
 	e := yaml.NewEncoder(buf)
 	e.SetIndent(f.Config.Indent)
-	e.SetWidth(f.Config.LineLength)
+	if f.Config.LineLength > 0 {
+		e.SetWidth(f.Config.LineLength)
+	}
 	if f.Config.LineEnding == yamlfmt.LineBreakStyleCRLF {
 		e.SetLineBreakStyle(yaml.LineBreakStyleCRLF)
 	}


### PR DESCRIPTION
Hi,
In the following link, you described the `max_line_length` configuration, which has `-1` as the default value.
https://github.com/google/yamlfmt/blob/main/docs/config.md#configuration-1
But when I run without that configuration,  It doesn't work as expected.
Because `Config` does not set default value of `LineLength` and it is set to `0`.

https://github.com/braydonk/yaml/blob/27e8120d48dc02f05289574102ad5ee2ea69693c/apic.go#L177
It set 0 and finally set the default length to `80`.
``` golang
// Set the preferred line width.
func yaml_emitter_set_width(emitter *yaml_emitter_t, width int) {
	if width < 0 {
		width = -1
	}
	emitter.best_width = width
}
```
```golang
// https://github.com/braydonk/yaml/blob/27e8120d48dc02f05289574102ad5ee2ea69693c/emitterc.go#L250
	if emitter.best_width >= 0 && emitter.best_width <= emitter.best_indent*2 {
		emitter.best_width = 80
	}
```

So I modified it to be disabled by setting the default value to `-1`.
