### PR TITLE
pre-commit: fixed bad idea for entry

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: yamlfmt
   name: yamlfmt 
   description: This hook uses github.com/google/yamlfmt to format yaml files. Requires golang >1.18 to be installed.
-  entry: yamlfmt .
+  entry: yamlfmt
   language: golang
   types: [yaml]


### PR DESCRIPTION
Since pre-commit passes filenames that it finds as positional arguments, running `yamlfmt .` would basically run on the whole directory every time it finds a yaml file. This new entry should work more like other hooks do.