### PR TITLE
basic: add indentless_array option

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -63,8 +63,9 @@ The basic formatter is a barebones formatter that simply takes the data provided
 | `line_ending`            | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings. This setting will be overwritten by the global `line_ending`. |
 | `retain_line_breaks`     | bool           | false   | Retain line breaks in formatted yaml |
 | `disallow_anchors`       | bool           | false   | If true, reject any YAML anchors or aliases found in the document. |
-| `max_line_length`        | int            | 0      | Set the maximum line length (see notes below). if not set, defaults to 0 which means no limit. |
+| `max_line_length`        | int            | 0       | Set the maximum line length (see notes below). if not set, defaults to 0 which means no limit. |
 | `scan_folded_as_literal` | bool           | false   | Option that will preserve newlines in folded block scalars (blocks that start with `>`). |
+| `indentless_array`       | bool           | false   | Render `-` array items (block sequence items) without an increased indent. |
 
 ### Note on `max_line_length`
 

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	RetainLineBreaks     bool                   `mapstructure:"retain_line_breaks"`
 	DisallowAnchors      bool                   `mapstructure:"disallow_anchors"`
 	ScanFoldedAsLiteral  bool                   `mapstructure:"scan_folded_as_literal"`
+	IndentlessArrays     bool                   `mapstructure:"indentless_arrays"`
 }
 
 func DefaultConfig() *Config {

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -96,17 +96,18 @@ func (f *BasicFormatter) getNewDecoder(reader io.Reader) *yaml.Decoder {
 func (f *BasicFormatter) getNewEncoder(buf *bytes.Buffer) *yaml.Encoder {
 	e := yaml.NewEncoder(buf)
 	e.SetIndent(f.Config.Indent)
+
 	if f.Config.LineLength > 0 {
 		e.SetWidth(f.Config.LineLength)
 	}
+
 	if f.Config.LineEnding == yamlfmt.LineBreakStyleCRLF {
 		e.SetLineBreakStyle(yaml.LineBreakStyleCRLF)
 	}
-	if f.Config.IncludeDocumentStart {
-		e.SetExplicitDocumentStart()
-	}
-	if f.Config.ScanFoldedAsLiteral {
-		e.SetAssumeBlockAsLiteral(true)
-	}
+
+	e.SetExplicitDocumentStart(f.Config.IncludeDocumentStart)
+	e.SetAssumeBlockAsLiteral(f.Config.ScanFoldedAsLiteral)
+	e.SetIndentlessBlockSequence(f.Config.IndentlessArrays)
+
 	return e
 }

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/RageCage64/multilinediff v0.2.0
-	github.com/bmatcuk/doublestar/v4 v4.2.0
-	github.com/braydonk/yaml v0.4.0
+	github.com/bmatcuk/doublestar/v4 v4.6.0
+	github.com/braydonk/yaml v0.5.0
 	github.com/mitchellh/mapstructure v1.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,12 @@ github.com/RageCage64/multilinediff v0.2.0 h1:yNSpSF5NXIrmo6bRIgO4Q0g7SXqFD4j/WE
 github.com/RageCage64/multilinediff v0.2.0/go.mod h1:pKr+KLgP0gvRzA+yv0/IUaYQuBYN1ucWysvsL58aMP0=
 github.com/bmatcuk/doublestar/v4 v4.2.0 h1:Qu+u9wR3Vd89LnlLMHvnZ5coJMWKQamqdz9/p5GNthA=
 github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/braydonk/yaml v0.4.0 h1:MNjdriecuspytC31J7Tzx6O8b1yAbMSTGvRG6vLSXZc=
 github.com/braydonk/yaml v0.4.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
+github.com/braydonk/yaml v0.5.0 h1:j1SlSSD9JLRKgkmFb66hsDH4D0YFlLOLXSXDwNH9/LU=
+github.com/braydonk/yaml v0.5.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
Updates the yaml library and adds a new option for indentless arrays.

See https://github.com/braydonk/yaml/pull/13 for library changes.

Closes #87 