### PR TITLE
cmd: initialize config fields before use

### DIFF
--- a/cmd/yamlfmt/config.go
+++ b/cmd/yamlfmt/config.go
@@ -175,7 +175,7 @@ func validatePath(path string) error {
 }
 
 func makeCommandConfigFromData(configData map[string]any) (*command.Config, error) {
-	var config *command.Config
+	config := command.NewConfig()
 	err := mapstructure.Decode(configData, &config)
 	if err != nil {
 		return nil, err
@@ -222,7 +222,7 @@ func makeCommandConfigFromData(configData map[string]any) (*command.Config, erro
 	config.Exclude = append(config.Exclude, flagExclude...)
 	config.Extensions = append(config.Extensions, flagExtensions...)
 
-	return config, nil
+	return &config, nil
 }
 
 func parseFormatterConfigFlag(flagValues []string) (map[string]any, error) {

--- a/command/command.go
+++ b/command/command.go
@@ -40,6 +40,11 @@ type FormatterConfig struct {
 	FormatterSettings map[string]any `mapstructure:",remain"`
 }
 
+// NewFormatterConfig returns an empty formatter config with all fields initialized.
+func NewFormatterConfig() FormatterConfig {
+	return FormatterConfig{FormatterSettings: make(map[string]any)}
+}
+
 type Config struct {
 	Extensions      []string               `mapstructure:"extensions"`
 	Include         []string               `mapstructure:"include"`
@@ -47,6 +52,12 @@ type Config struct {
 	Doublestar      bool                   `mapstructure:"doublestar"`
 	LineEnding      yamlfmt.LineBreakStyle `mapstructure:"line_ending"`
 	FormatterConfig *FormatterConfig       `mapstructure:"formatter,omitempty"`
+}
+
+// NewConfig returns an empty config with all fields initialized.
+func NewConfig() Config {
+	formatterConfig := NewFormatterConfig()
+	return Config{FormatterConfig: &formatterConfig}
 }
 
 type Command struct {


### PR DESCRIPTION
Fixes https://github.com/google/yamlfmt/issues/99 by introducing config constructors
Note that this is one way to fix the issue, alternatives can be considered too

Without any `.yamlfmt`, `yamlfmt` behaves as expected, here below with debug logs : 

```text
$ rm .yamlfmt

$ go run ./cmd/yamlfmt
{Extensions:[yaml yml] Include:[] Exclude:[] Doublestar:false LineEnding:lf FormatterConfig:0x14000120168}
{Type: FormatterSettings:map[]}

$ go run ./cmd/yamlfmt --formatter retain_line_breaks=true
{Extensions:[yaml yml] Include:[] Exclude:[] Doublestar:false LineEnding:lf FormatterConfig:0x14000118150}
{Type: FormatterSettings:map[retain_line_breaks:true]}
```

Same expected behavior when `.yamlfmt` contains no overrides : 

```text
$ cat .yamlfmt
formatter:
  type: basic

$ go run ./cmd/yamlfmt
{Extensions:[yaml yml] Include:[] Exclude:[] Doublestar:false LineEnding:lf FormatterConfig:0x14000124168}
{Type:basic FormatterSettings:map[]}

$ go run ./cmd/yamlfmt --formatter retain_line_breaks=true
{Extensions:[yaml yml] Include:[] Exclude:[] Doublestar:false LineEnding:lf FormatterConfig:0x1400000c180}
{Type:basic FormatterSettings:map[retain_line_breaks:true]}
```

Same expected behavior when `.yamlfmt` contains at least one overrides : 

```text
$ cat .yamlfmt
formatter:
  type: basic
  retain_line_breaks: false

$ go run ./cmd/yamlfmt
{Extensions:[yaml yml] Include:[] Exclude:[] Doublestar:false LineEnding:lf FormatterConfig:0x14000114168}
{Type:basic FormatterSettings:map[retain_line_breaks:false]}

$ go run ./cmd/yamlfmt --formatter retain_line_breaks=true
{Extensions:[yaml yml] Include:[] Exclude:[] Doublestar:false LineEnding:lf FormatterConfig:0x140000a0168}
{Type:basic FormatterSettings:map[retain_line_breaks:true]}
```