### PR TITLE
formatter: add pad_line_comments option

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -57,6 +57,7 @@ The basic formatter is a barebones formatter that simply takes the data provided
 | `scan_folded_as_literal` | bool           | false   | Option that will preserve newlines in folded block scalars (blocks that start with `>`). |
 | `indentless_arrays`      | bool           | false   | Render `-` array items (block sequence items) without an increased indent. |
 | `drop_merge_tag`         | bool           | false   | Assume that any well formed merge using just a `<<` token will be a merge, and drop the `!!merge` tag from the formatted result. |
+| `pad_line_comments`      | int            | 1       | The number of padding spaces to insert before line comments. |
 
 ### Note on `max_line_length`
 

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ScanFoldedAsLiteral  bool                   `mapstructure:"scan_folded_as_literal"`
 	IndentlessArrays     bool                   `mapstructure:"indentless_arrays"`
 	DropMergeTag         bool                   `mapstructure:"drop_merge_tag"`
+	PadLineComments      int                    `mapstructure:"pad_line_comments"`
 }
 
 func DefaultConfig() *Config {
@@ -38,7 +39,8 @@ func DefaultConfig() *Config {
 		lineBreakStyle = yamlfmt.LineBreakStyleCRLF
 	}
 	return &Config{
-		Indent:     2,
-		LineEnding: lineBreakStyle,
+		Indent:          2,
+		LineEnding:      lineBreakStyle,
+		PadLineComments: 1,
 	}
 }

--- a/formatters/basic/factory_test.go
+++ b/formatters/basic/factory_test.go
@@ -36,6 +36,7 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 				Indent:               4,
 				IncludeDocumentStart: false,
 				LineEnding:           yamlfmt.LineBreakStyleLF,
+				PadLineComments:      1,
 			},
 		},
 		{
@@ -47,6 +48,7 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 				Indent:               2,
 				IncludeDocumentStart: true,
 				LineEnding:           yamlfmt.LineBreakStyleLF,
+				PadLineComments:      1,
 			},
 		},
 		{
@@ -58,6 +60,19 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 				Indent:               2,
 				IncludeDocumentStart: false,
 				LineEnding:           yamlfmt.LineBreakStyleCRLF,
+				PadLineComments:      1,
+			},
+		},
+		{
+			name: "only pad_line_comments specified",
+			configMap: map[string]interface{}{
+				"pad_line_comments": 2,
+			},
+			expectedConfig: basic.Config{
+				Indent:               2,
+				IncludeDocumentStart: false,
+				LineEnding:           yamlfmt.LineBreakStyleLF,
+				PadLineComments:      2,
 			},
 		},
 		{
@@ -66,11 +81,13 @@ func TestNewWithConfigRetainsDefaultValues(t *testing.T) {
 				"indent":                 4,
 				"line_ending":            "crlf",
 				"include_document_start": true,
+				"pad_line_comments":      2,
 			},
 			expectedConfig: basic.Config{
 				Indent:               4,
 				IncludeDocumentStart: true,
 				LineEnding:           yamlfmt.LineBreakStyleCRLF,
+				PadLineComments:      2,
 			},
 		},
 	}

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -109,6 +109,7 @@ func (f *BasicFormatter) getNewEncoder(buf *bytes.Buffer) *yaml.Encoder {
 	e.SetAssumeBlockAsLiteral(f.Config.ScanFoldedAsLiteral)
 	e.SetIndentlessBlockSequence(f.Config.IndentlessArrays)
 	e.SetDropMergeTag(f.Config.DropMergeTag)
+	e.SetPadLineComments(f.Config.PadLineComments)
 
 	return e
 }

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -269,3 +269,21 @@ b:
 		t.Fatalf("expected formatted result to drop merge tag, was found:\n%s", resultStr)
 	}
 }
+
+func TestPadLineComments(t *testing.T) {
+	config := basic.DefaultConfig()
+	config.PadLineComments = 2
+	f := newFormatter(config)
+
+	yml := "a: 1 # line comment"
+	expectedStr := "a: 1  # line comment"
+
+	result, err := f.Format([]byte(yml))
+	if err != nil {
+		t.Fatalf("expected formatting to pass, returned error: %v", err)
+	}
+	resultStr := strings.TrimSuffix(string(result), "\n")
+	if resultStr != expectedStr {
+		t.Fatalf("expected: '%s', got: '%s'", expectedStr, resultStr)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/RageCage64/multilinediff v0.2.0
 	github.com/bmatcuk/doublestar/v4 v4.6.0
-	github.com/braydonk/yaml v0.6.0
+	github.com/braydonk/yaml v0.7.0
 	github.com/mitchellh/mapstructure v1.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,9 @@
 github.com/RageCage64/multilinediff v0.2.0 h1:yNSpSF5NXIrmo6bRIgO4Q0g7SXqFD4j/WEcBE+BdCFY=
 github.com/RageCage64/multilinediff v0.2.0/go.mod h1:pKr+KLgP0gvRzA+yv0/IUaYQuBYN1ucWysvsL58aMP0=
-github.com/bmatcuk/doublestar/v4 v4.2.0 h1:Qu+u9wR3Vd89LnlLMHvnZ5coJMWKQamqdz9/p5GNthA=
-github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
 github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/braydonk/yaml v0.4.0 h1:MNjdriecuspytC31J7Tzx6O8b1yAbMSTGvRG6vLSXZc=
-github.com/braydonk/yaml v0.4.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
-github.com/braydonk/yaml v0.5.0 h1:j1SlSSD9JLRKgkmFb66hsDH4D0YFlLOLXSXDwNH9/LU=
-github.com/braydonk/yaml v0.5.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
-github.com/braydonk/yaml v0.6.0 h1:nHt2AzmV4yMhXSNROksvkTgAxzollgy7uVOKfCVXhMo=
-github.com/braydonk/yaml v0.6.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
+github.com/braydonk/yaml v0.7.0 h1:ySkqO7r0MGoCNhiRJqE0Xe9yhINMyvOAB3nFjgyJn2k=
+github.com/braydonk/yaml v0.7.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
Fixes https://github.com/google/yamlfmt/issues/104 using https://github.com/braydonk/yaml/pull/16

Add an option to change the number of padding spaces between the yaml content and the first `#` of a line comment
Keeping 1 as the default value for backward compatibility, although using 2 would make sense as it would be compliant with `yamllint` default rules

Example of usage : 

```bash
$ cat comments.yaml
key: "value" # line comment

$ yamlfmt --formatter pad_line_comments=2 comments.yaml

$ cat comments.yaml
key: "value"  # line comment
```

Also remove unneeded entries from the go sum file