### PR TITLE
yamlfmt: add continue_on_error flag

### DIFF
--- a/cmd/yamlfmt/config.go
+++ b/cmd/yamlfmt/config.go
@@ -209,9 +209,14 @@ func makeCommandConfigFromData(configData map[string]any) (*command.Config, erro
 		config.Extensions = []string{"yaml", "yml"}
 	}
 
-	// Default to flag if not set in config
+	// Default to doublestar flag if not set in config
 	if !config.Doublestar {
-		config.Doublestar = useDoublestar()
+		config.Doublestar = *flagDoublestar
+	}
+
+	// Default to continue_on_error flag if not set in config
+	if !config.ContinueOnError {
+		config.ContinueOnError = *flagContinueOnError
 	}
 
 	// Overwrite config if includes are provided through args

--- a/cmd/yamlfmt/flags.go
+++ b/cmd/yamlfmt/flags.go
@@ -27,13 +27,14 @@ var (
 source yaml and formatted yaml.`)
 	flagDry *bool = flag.Bool("dry", false, `Perform a dry run; show the output of a formatting
 operation without performing it.`)
-	flagIn         *bool   = flag.Bool("in", false, "Format yaml read from stdin and output to stdout")
-	flagConf       *string = flag.String("conf", "", "Read yamlfmt config from this path")
-	flagDoublestar *bool   = flag.Bool("dstar", false, "Use doublestar globs for include and exclude")
-	flagQuiet      *bool   = flag.Bool("quiet", false, "Print minimal output to stdout")
-	flagExclude            = arrayFlag{}
-	flagFormatter          = arrayFlag{}
-	flagExtensions         = arrayFlag{}
+	flagIn              *bool   = flag.Bool("in", false, "Format yaml read from stdin and output to stdout")
+	flagConf            *string = flag.String("conf", "", "Read yamlfmt config from this path")
+	flagDoublestar      *bool   = flag.Bool("dstar", false, "Use doublestar globs for include and exclude")
+	flagQuiet           *bool   = flag.Bool("quiet", false, "Print minimal output to stdout")
+	flagContinueOnError *bool   = flag.Bool("continue_on_error", false, "Continue to format files that didn't fail instead of exiting with code 1.")
+	flagExclude                 = arrayFlag{}
+	flagFormatter               = arrayFlag{}
+	flagExtensions              = arrayFlag{}
 )
 
 func bindArrayFlags() {
@@ -95,8 +96,4 @@ func isStdinArg() bool {
 	}
 	arg := flag.Args()[0]
 	return arg == "-" || arg == "/dev/stdin"
-}
-
-func useDoublestar() bool {
-	return *flagDoublestar
 }

--- a/command/command.go
+++ b/command/command.go
@@ -51,6 +51,7 @@ type Config struct {
 	Exclude         []string               `mapstructure:"exclude"`
 	RegexExclude    []string               `mapstructure:"regex_exclude"`
 	Doublestar      bool                   `mapstructure:"doublestar"`
+	ContinueOnError bool                   `mapstructure:"continue_on_error"`
 	LineEnding      yamlfmt.LineBreakStyle `mapstructure:"line_ending"`
 	FormatterConfig *FormatterConfig       `mapstructure:"formatter,omitempty"`
 }
@@ -109,6 +110,7 @@ func (c *Command) Run() error {
 		LineSepCharacter: lineSepChar,
 		Formatter:        formatter,
 		Quiet:            c.Quiet,
+		ContinueOnError:  c.Config.ContinueOnError,
 	}
 
 	collectedPaths, err := c.collectPaths()

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -20,6 +20,7 @@ The command package defines the main command engine that `cmd/yamlfmt` uses. It 
 |:-------------------------|:---------------|:--------|:------------|
 | `line_ending`            | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings. This global setting will override any formatter `line_ending` options. |
 | `doublestar`             | bool           | false   | Use [doublestar](https://github.com/bmatcuk/doublestar) for include and exclude paths. (This was the default before 0.7.0) |
+| `continue_on_error`      | bool           | false   | Continue formatting and don't exit with code 1 when there is an invalid yaml file found. |
 | `include`                | []string       | []      | The paths for the command to include for formatting. See [Specifying Paths][] for more details. |
 | `exclude`                | []string       | []      | The paths for the command to exclude from formatting. See [Specifying Paths][] for more details. |
 | `regex_exclude`          | []string       | []      | Regex patterns to match file contents for, if the file content matches the regex the file will be excluded. Use [Golang regexes](https://regex101.com/). |

--- a/engine/consecutive_engine.go
+++ b/engine/consecutive_engine.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"log"
 	"os"
 
 	"github.com/google/yamlfmt"
@@ -25,6 +26,7 @@ type ConsecutiveEngine struct {
 	LineSepCharacter string
 	Formatter        yamlfmt.Formatter
 	Quiet            bool
+	ContinueOnError  bool
 }
 
 func (e *ConsecutiveEngine) FormatContent(content []byte) ([]byte, error) {
@@ -34,7 +36,12 @@ func (e *ConsecutiveEngine) FormatContent(content []byte) ([]byte, error) {
 func (e *ConsecutiveEngine) Format(paths []string) error {
 	formatDiffs, formatErrs := e.formatAll(paths)
 	if len(formatErrs) > 0 {
-		return formatErrs
+		if e.ContinueOnError {
+			log.Print(formatErrs)
+			log.Println("Continuing...")
+		} else {
+			return formatErrs
+		}
 	}
 	return formatDiffs.ApplyAll()
 }


### PR DESCRIPTION
Adds a new flag to continue formatting even if there are some invalid yaml files found. Suggested in #114 