### PR TITLE
feat: add flag to print version

### DIFF
--- a/cmd/yamlfmt/flags.go
+++ b/cmd/yamlfmt/flags.go
@@ -28,6 +28,7 @@ source yaml and formatted yaml.`)
 	flagDry *bool = flag.Bool("dry", false, `Perform a dry run; show the output of a formatting
 operation without performing it.`)
 	flagIn              *bool   = flag.Bool("in", false, "Format yaml read from stdin and output to stdout")
+	flagVersion         *bool   = flag.Bool("version", false, "Print yamlfmt version")
 	flagConf            *string = flag.String("conf", "", "Read yamlfmt config from this path")
 	flagDoublestar      *bool   = flag.Bool("dstar", false, "Use doublestar globs for include and exclude")
 	flagQuiet           *bool   = flag.Bool("quiet", false, "Print minimal output to stdout")
@@ -86,6 +87,9 @@ func getOperationFromFlag() command.Operation {
 	}
 	if *flagDry {
 		return command.OperationDry
+	}
+	if *flagVersion {
+		return command.OperationVersion
 	}
 	return command.OperationFormat
 }

--- a/cmd/yamlfmt/flags.go
+++ b/cmd/yamlfmt/flags.go
@@ -88,9 +88,6 @@ func getOperationFromFlag() command.Operation {
 	if *flagDry {
 		return command.OperationDry
 	}
-	if *flagVersion {
-		return command.OperationVersion
-	}
 	return command.OperationFormat
 }
 

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/google/yamlfmt"
 	"github.com/google/yamlfmt/command"
@@ -35,6 +37,15 @@ func run() error {
 	bindArrayFlags()
 	configureHelp()
 	flag.Parse()
+
+	if *flagVersion {
+		_, err := fmt.Printf("%s\n", version)
+		if err != nil {
+			return err
+		}
+
+		os.Exit(0)
+	}
 
 	c := &command.Command{
 		Operation: getOperationFromFlag(),

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/yamlfmt/formatters/basic"
 )
 
+var version string = "0.10.0"
+
 func main() {
 	if err := run(); err != nil {
 		log.Fatal(err)
@@ -58,7 +60,7 @@ func run() error {
 	}
 	c.Config = commandConfig
 
-	return c.Run()
+	return c.Run(version)
 }
 
 func getFullRegistry() *yamlfmt.Registry {

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/google/yamlfmt"
 	"github.com/google/yamlfmt/command"
@@ -39,12 +38,8 @@ func run() error {
 	flag.Parse()
 
 	if *flagVersion {
-		_, err := fmt.Printf("%s\n", version)
-		if err != nil {
-			return err
-		}
-
-		os.Exit(0)
+		fmt.Printf("%s\n", version)
+		return nil
 	}
 
 	c := &command.Command{

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -71,7 +71,7 @@ func run() error {
 	}
 	c.Config = commandConfig
 
-	return c.Run(version)
+	return c.Run()
 }
 
 func getFullRegistry() *yamlfmt.Registry {

--- a/command/command.go
+++ b/command/command.go
@@ -69,7 +69,7 @@ type Command struct {
 	Quiet     bool
 }
 
-func (c *Command) Run(version string) error {
+func (c *Command) Run() error {
 	var formatter yamlfmt.Formatter
 	if c.Config.FormatterConfig == nil {
 		factory, err := c.Registry.GetDefaultFactory()

--- a/command/command.go
+++ b/command/command.go
@@ -33,7 +33,6 @@ const (
 	OperationLint
 	OperationDry
 	OperationStdin
-	OperationVersion
 )
 
 type FormatterConfig struct {
@@ -161,8 +160,6 @@ func (c *Command) Run(version string) error {
 			return err
 		}
 		fmt.Print(string(out))
-	case OperationVersion:
-		fmt.Printf("%s\n", version)
 	}
 
 	return nil

--- a/command/command.go
+++ b/command/command.go
@@ -33,6 +33,7 @@ const (
 	OperationLint
 	OperationDry
 	OperationStdin
+	OperationVersion
 )
 
 type FormatterConfig struct {
@@ -69,7 +70,7 @@ type Command struct {
 	Quiet     bool
 }
 
-func (c *Command) Run() error {
+func (c *Command) Run(version string) error {
 	var formatter yamlfmt.Formatter
 	if c.Config.FormatterConfig == nil {
 		factory, err := c.Registry.GetDefaultFactory()
@@ -160,6 +161,8 @@ func (c *Command) Run() error {
 			return err
 		}
 		fmt.Print(string(out))
+	case OperationVersion:
+		fmt.Printf("%s\n", version)
 	}
 
 	return nil

--- a/docs/command-usage.md
+++ b/docs/command-usage.md
@@ -59,13 +59,14 @@ All flags must be specified **before** any path arguments.
 
 These flags adjust the command's mode of operation. All of these flags are booleans.
 
-| Name       | Flag     | Example                    | Description |
-|:-----------|:---------|:---------------------------|:------------|
-| Help       | `-help`  | `yamlfmt -help`            | Print the command usage information. |
-| Dry Run    | `-dry`   | `yamlfmt -dry .`           | Use [Dry Run](#dry-run) mode |
-| Lint       | `-lint`  | `yamlfmt -lint .`          | Use [Lint](#lint) mode |
-| Quiet Mode | `-quiet` | `yamlfmt -dry -quiet .`    | Use quiet mode. Only has effect in Dry Run or Lint modes. |
-| Read Stdin | `-in`    | `cat x.yaml | yamlfmt -in` | Read input from stdin and output result to stdout. |
+| Name          | Flag       | Example                     | Description                                               |
+| :------------ | :--------- | :-------------------------- | :-------------------------------------------------------- |
+| Help          | `-help`    | `yamlfmt -help`             | Print the command usage information.                      |
+| Print Version | `-version` | `yamlfmt -version`          | Print the yamlfmt version.                                |
+| Dry Run       | `-dry`     | `yamlfmt -dry .`            | Use [Dry Run](#dry-run) mode                              |
+| Lint          | `-lint`    | `yamlfmt -lint .`           | Use [Lint](#lint) mode                                    |
+| Quiet Mode    | `-quiet`   | `yamlfmt -dry -quiet .`     | Use quiet mode. Only has effect in Dry Run or Lint modes. |
+| Read Stdin    | `-in`      | `cat x.yaml \| yamlfmt -in` | Read input from stdin and output result to stdout.        |
 
 ### Configuration Flags
 


### PR DESCRIPTION
When I addressed to create asdf plugin, the way to ensure the version of the binary is not found.
This feature always helps me. So I added a simple flag to print the version.

https://github.com/kachick/asdf-yamlfmt
https://github.com/asdf-vm/asdf-plugins/pull/829