### PR TITLE
docs: fix missing markdown escape

### DIFF
--- a/docs/command-usage.md
+++ b/docs/command-usage.md
@@ -59,13 +59,13 @@ All flags must be specified **before** any path arguments.
 
 These flags adjust the command's mode of operation. All of these flags are booleans.
 
-| Name       | Flag     | Example                    | Description |
-|:-----------|:---------|:---------------------------|:------------|
-| Help       | `-help`  | `yamlfmt -help`            | Print the command usage information. |
-| Dry Run    | `-dry`   | `yamlfmt -dry .`           | Use [Dry Run](#dry-run) mode |
-| Lint       | `-lint`  | `yamlfmt -lint .`          | Use [Lint](#lint) mode |
-| Quiet Mode | `-quiet` | `yamlfmt -dry -quiet .`    | Use quiet mode. Only has effect in Dry Run or Lint modes. |
-| Read Stdin | `-in`    | `cat x.yaml | yamlfmt -in` | Read input from stdin and output result to stdout. |
+| Name       | Flag     | Example                     | Description                                               |
+| :--------- | :------- | :-------------------------- | :-------------------------------------------------------- |
+| Help       | `-help`  | `yamlfmt -help`             | Print the command usage information.                      |
+| Dry Run    | `-dry`   | `yamlfmt -dry .`            | Use [Dry Run](#dry-run) mode                              |
+| Lint       | `-lint`  | `yamlfmt -lint .`           | Use [Lint](#lint) mode                                    |
+| Quiet Mode | `-quiet` | `yamlfmt -dry -quiet .`     | Use quiet mode. Only has effect in Dry Run or Lint modes. |
+| Read Stdin | `-in`    | `cat x.yaml \| yamlfmt -in` | Read input from stdin and output result to stdout.        |
 
 ### Configuration Flags
 


### PR DESCRIPTION
Rich diff might help to review https://github.com/google/yamlfmt/pull/119/files?short_path=957151c#diff-957151c97e5c70c8a4f2f19387236d55637362dd5d1a18a2b7129afce5cf050e

---

Before
---

<img width="816" alt="スクリーンショット 2023-05-29 184542" src="https://github.com/google/yamlfmt/assets/1180335/00776aa6-ce02-48b7-9008-cae4d1313337">

After
---

<img width="844" alt="スクリーンショット 2023-05-29 184959" src="https://github.com/google/yamlfmt/assets/1180335/d9a9c105-87a1-42cd-b20d-1288aabaa6a6">
