### PR TITLE
cmd: fixed to display dry-run outputs.

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -145,7 +145,7 @@ func (c *Command) Run() error {
 		if err != nil {
 			return err
 		}
-		if out.Message == "" {
+		if out.Message == "" && out.Files.ChangedCount() == 0 {
 			log.Print("No files will be changed.")
 		} else {
 			log.Print(out)


### PR DESCRIPTION
Fixed a bug that the diffs were not displayed when running dry run even if FileDiffs existed.

## Details

In [this PR](https://github.com/google/yamlfmt/pull/90), quiet mode has been added

When running DryRun, messages will not be returned except in quiet mode
https://github.com/google/yamlfmt/pull/90/files#diff-9a5c609cc998c3fec5e5e127bbb7b37c8059b50713b6c2686344d43176b999d9R63-R77

In a subsequent PR, if there is no message, it has been changed so that the differences will not be output to stdout during DryRun
https://github.com/google/yamlfmt/pull/106/files#diff-9411b7c0f7187e3e94ff7f48851c1d31db3607a56078f9aa6bb1ae80121efbcfR146-R150

However, when you run dry-run, you should expect to see the differences.