### PR TITLE
goreleaser: replacements is deprecated

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,12 +26,14 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{- .Arch }}{{- end }}
+      {{- if .Arm }}v{{- .Arm }}{{- end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -43,3 +45,4 @@ changelog:
       - '^docs:'
       - '^test:'
       - '^ci:'
+


### PR DESCRIPTION
`archives.replacements` was removed in a newer `goreleaser` version so I have to do this name template stuff :sob: 