### PR TITLE
docs: language system pre-commit override

### DIFF
--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -4,9 +4,22 @@ Starting in v0.7.1, `yamlfmt` can be used as a hook for the popular [pre-commit]
 
 ```yaml
 - repo: https://github.com/google/yamlfmt
-  rev: v0.8.0
+  rev: v0.10.0
   hooks:
     - id: yamlfmt
 ```
 
 When running yamlfmt with the `pre-commit` hook, the only way to configure it is through a `.yamlfmt` configuration file in the root of the repo or a system wide config directory (see [Configuration File](./config-file.md) docs). 
+
+## Use `yamlfmt` installed on the system instead of pre-commit building with Go
+
+If you would prefer to manage your `yamlfmt` installation yourself, you can have the hook use your installed `yamlfmt` binary instead. As long as `yamlfmt` is in your PATH, you can override the `language` setting to `system`.
+
+```yaml
+- repo: https://github.com/google/yamlfmt
+  rev: v0.10.0
+  hooks:
+    - id: yamlfmt
+      language: system
+```
+


### PR DESCRIPTION
`pre-commit` allows you to override any settings for hooks in your personal config. This override is useful to document here, since it will allow users to use a yamlfmt binary on their system instead of being forced into building it with Go for the purpose of the hook.