### PR TITLE
New config discovery procedure

### DIFF
--- a/cmd/yamlfmt/flags.go
+++ b/cmd/yamlfmt/flags.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/google/yamlfmt/command"
@@ -30,6 +31,7 @@ operation without performing it.`)
 	flagIn              *bool   = flag.Bool("in", false, "Format yaml read from stdin and output to stdout")
 	flagVersion         *bool   = flag.Bool("version", false, "Print yamlfmt version")
 	flagConf            *string = flag.String("conf", "", "Read yamlfmt config from this path")
+	flagGlobalConf      *bool   = flag.Bool("global_conf", false, globalConfFlagMessage())
 	flagDoublestar      *bool   = flag.Bool("dstar", false, "Use doublestar globs for include and exclude")
 	flagQuiet           *bool   = flag.Bool("quiet", false, "Print minimal output to stdout")
 	flagContinueOnError *bool   = flag.Bool("continue_on_error", false, "Continue to format files that didn't fail instead of exiting with code 1.")
@@ -67,12 +69,12 @@ func configureHelp() {
 	Arguments:
 
 	Glob paths to yaml files
-			Send any number of paths to yaml files specified in doublestar glob format (see: https://github.com/bmatcuk/doublestar). 
+			Send any number of paths to yaml files specified in doublestar glob format (see: https://github.com/bmatcuk/doublestar).
 			Any flags must be specified before the paths.
 
 	- or /dev/stdin
 			Passing in a single - or /dev/stdin will read the yaml from stdin and output the formatted result to stdout
-		
+
 	Flags:`)
 		flag.PrintDefaults()
 	}
@@ -97,4 +99,12 @@ func isStdinArg() bool {
 	}
 	arg := flag.Args()[0]
 	return arg == "-" || arg == "/dev/stdin"
+}
+
+func globalConfFlagMessage() string {
+	varName := "XDG_CONFIG_HOME"
+	if runtime.GOOS == "windows" {
+		varName = "LOCALAPPDATA"
+	}
+	return fmt.Sprintf("Use global yamlfmt config from %s", varName)
 }

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/yamlfmt/formatters/basic"
 )
 
-var version string = "0.10.0"
+var version string = "0.11.0"
 
 func main() {
 	if err := run(); err != nil {

--- a/docs/command-usage.md
+++ b/docs/command-usage.md
@@ -77,9 +77,10 @@ The string array flags can be a bit confusing. See the [String Array Flags](#str
 | Name             | Flag          | Type     | Example                                                   | Description |
 |:-----------------|:--------------|:---------|:----------------------------------------------------------|:------------|
 | Config File Path | `-conf`       | string   | `yamlfmt -conf ./config/.yamlfmt`                         | Specify a path to read a [configuration file](./config-file.md) from. |
+| Global Config    | `-global_conf`| bool     | `yamlfmt -global_conf ./config/.yamlfmt`                  | Force yamlfmt to use the configuration file from the system config directory. |
 | Doublstar        | `-dstar`      | boolean  | `yamlfmt -dstar "**/*.yaml"`                              | Enable [Doublstar](./paths.md#doublestar) path collection mode. |
 | Exclude          | `-exclude`    | []string | `yamlfmt -exclude ./not/,these_paths.yaml`                | Patterns to exclude from path collection. These add to exclude patterns specified in the [config file](./config-file.md) |
-| Extensions       | `-extensions` | []string | `yamlfmt -extensions yaml,yml`                            | Extensions to use in standard path collection. Has no effect in Doublestar mode. These add to extensions specified in the [config file](./config-file.md) 
+| Extensions       | `-extensions` | []string | `yamlfmt -extensions yaml,yml`                            | Extensions to use in standard path collection. Has no effect in Doublestar mode. These add to extensions specified in the [config file](./config-file.md)
 | Formatter Config | `-formatter`  | []string | `yamlfmt -formatter indent=2,include_document_start=true` | Provide configuration values for the formatter. See [Formatter Configuration Options](./config-file.md#basic-formatter) for options. Each field is specified as `configkey=value`. |
 
 #### String Array Flags

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1,14 +1,21 @@
-# Configuration With .yamlfmt
+# Configuration With .yamlfmt, yamlfmt.yaml, and yamlfmt.yml
 
 ## Config File Discovery
 
-The config file is discovered in the following priority order:
+The config file is a file named `.yamlfmt`, `yamlfmt.yaml`, or `yamlfmt.yml` that contains a valid yamlfmt configuration. The config file is discovered in the following priority order:
 
-1. Specified in the `--conf` flag (if this is an invalid path or doesn't exist, the tool will fail)
-2. A `.yamlfmt` file in the current working directory
-3. A `yamlfmt` folder with a `.yamlfmt` file in the system config directory (`$XDG_CONFIG_HOME`, `$HOME/.config`, `%LOCALAPPDATA%`) e.g. `$HOME/.config/yamlfmt/.yamlfmt`
+1. Specified in the `-conf` flag (if this is an invalid path or doesn't exist, the tool will fail)
+1. A config file in the current working directory
+1. The first config file found up the tree step by step from the current working directory
+1. A `yamlfmt` folder with a config file in the system config directory (`$XDG_CONFIG_HOME`, `$HOME/.config`, `%LOCALAPPDATA%`) e.g. `$HOME/.config/yamlfmt/.yamlfmt`
 
 If none of these are found, the tool's default configuration will be used.
+
+### Config File Discovery Caveats
+
+If the flag `-global_conf` is passed, all other steps will be circumvented and the config file will be discovered from the system config directory. See [the command line flag docs](./command-usage.md#configuration-flags).
+
+In the `-conf` flag, the config file will be named anything. As long as it's valid yaml, yamlfmt will read it as a config file. This can be useful for applying unique configs to different directories in a project. The automatic discovery paths do need to use one of the known names.
 
 ## Command
 

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1,4 +1,4 @@
-# Configuration With .yamlfmt, yamlfmt.yaml, and yamlfmt.yml
+# Configuration File
 
 ## Config File Discovery
 


### PR DESCRIPTION
Config discovery is changing, but it should be non-breaking.
* The search for a config now starts at the root directory and then searches up the tree to finding the lowest level one. This should help in larger monorepo setups when you want different configs in different places, or to fall back to some default higher in the tree. I am not 100% sure whether this will break some workflows but it will be pretty easy to either change back or provide a short-circuit if necessary.
* Added a new flag `-global_conf` that will force the usage of the config from `XDG_CONFIG_HOME`/`LOCALAPPDATA`
* The yamlfmt config can now be in `yamlfmt.yaml` or `yamlfmt.yml` instead of just `.yamlfmt`