### PR TITLE
Retain single line breaks

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -57,13 +57,13 @@ The basic formatter is a barebones formatter that simply takes the data provided
 
 ### Configuration
 
-| Key                      | Type           | Default | Description |
-|:-------------------------|:---------------|:--------|:------------|
-| `indent`                    | int            | 2       | The indentation level in spaces to use for the formatted yaml|
-| `include_document_start`    | bool           | false   | Include `---` at document start |
+| Key                         | Type           | Default | Description |
+|:----------------------------|:---------------|:--------|:------------|
+| `indent`                    | int            | 2       | The indentation level in spaces to use for the formatted yaml. |
+| `include_document_start`    | bool           | false   | Include `---` at document start. |
 | `line_ending`               | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings. This setting will be overwritten by the global `line_ending`. |
-| `retain_line_breaks`        | bool           | false   | Retain line breaks in formatted yaml |
-| `retain_line_breaks_single` | bool           | false   | (NOTE: Takes precedence over `retain_line_breaks`) Retain line breaks in formatted yaml but only keep a single line in groups of many blank lines. |
+| `retain_line_breaks`        | bool           | false   | Retain line breaks in formatted yaml. |
+| `retain_line_breaks_single` | bool           | false   | (NOTE: Takes precedence over `retain_line_breaks`) Retain line breaks in formatted yaml, but only keep a single line in groups of many blank lines. |
 | `disallow_anchors`          | bool           | false   | If true, reject any YAML anchors or aliases found in the document. |
 | `max_line_length`           | int            | 0       | Set the maximum line length (see notes below). if not set, defaults to 0 which means no limit. |
 | `scan_folded_as_literal`    | bool           | false   | Option that will preserve newlines in folded block scalars (blocks that start with `>`). |

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -59,16 +59,17 @@ The basic formatter is a barebones formatter that simply takes the data provided
 
 | Key                      | Type           | Default | Description |
 |:-------------------------|:---------------|:--------|:------------|
-| `indent`                 | int            | 2       | The indentation level in spaces to use for the formatted yaml|
-| `include_document_start` | bool           | false   | Include `---` at document start |
-| `line_ending`            | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings. This setting will be overwritten by the global `line_ending`. |
-| `retain_line_breaks`     | bool           | false   | Retain line breaks in formatted yaml |
-| `disallow_anchors`       | bool           | false   | If true, reject any YAML anchors or aliases found in the document. |
-| `max_line_length`        | int            | 0       | Set the maximum line length (see notes below). if not set, defaults to 0 which means no limit. |
-| `scan_folded_as_literal` | bool           | false   | Option that will preserve newlines in folded block scalars (blocks that start with `>`). |
-| `indentless_arrays`      | bool           | false   | Render `-` array items (block sequence items) without an increased indent. |
-| `drop_merge_tag`         | bool           | false   | Assume that any well formed merge using just a `<<` token will be a merge, and drop the `!!merge` tag from the formatted result. |
-| `pad_line_comments`      | int            | 1       | The number of padding spaces to insert before line comments. |
+| `indent`                    | int            | 2       | The indentation level in spaces to use for the formatted yaml|
+| `include_document_start`    | bool           | false   | Include `---` at document start |
+| `line_ending`               | `lf` or `crlf` | `crlf` on Windows, `lf` otherwise | Parse and write the file with "lf" or "crlf" line endings. This setting will be overwritten by the global `line_ending`. |
+| `retain_line_breaks`        | bool           | false   | Retain line breaks in formatted yaml |
+| `retain_line_breaks_single` | bool           | false   | (NOTE: Takes precedence over `retain_line_breaks`) Retain line breaks in formatted yaml but only keep a single line in groups of many blank lines. |
+| `disallow_anchors`          | bool           | false   | If true, reject any YAML anchors or aliases found in the document. |
+| `max_line_length`           | int            | 0       | Set the maximum line length (see notes below). if not set, defaults to 0 which means no limit. |
+| `scan_folded_as_literal`    | bool           | false   | Option that will preserve newlines in folded block scalars (blocks that start with `>`). |
+| `indentless_arrays`         | bool           | false   | Render `-` array items (block sequence items) without an increased indent. |
+| `drop_merge_tag`            | bool           | false   | Assume that any well formed merge using just a `<<` token will be a merge, and drop the `!!merge` tag from the formatted result. |
+| `pad_line_comments`         | int            | 1       | The number of padding spaces to insert before line comments. |
 
 ### Note on `max_line_length`
 

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -21,16 +21,17 @@ import (
 )
 
 type Config struct {
-	Indent               int                    `mapstructure:"indent"`
-	IncludeDocumentStart bool                   `mapstructure:"include_document_start"`
-	LineEnding           yamlfmt.LineBreakStyle `mapstructure:"line_ending"`
-	LineLength           int                    `mapstructure:"max_line_length"`
-	RetainLineBreaks     bool                   `mapstructure:"retain_line_breaks"`
-	DisallowAnchors      bool                   `mapstructure:"disallow_anchors"`
-	ScanFoldedAsLiteral  bool                   `mapstructure:"scan_folded_as_literal"`
-	IndentlessArrays     bool                   `mapstructure:"indentless_arrays"`
-	DropMergeTag         bool                   `mapstructure:"drop_merge_tag"`
-	PadLineComments      int                    `mapstructure:"pad_line_comments"`
+	Indent                 int                    `mapstructure:"indent"`
+	IncludeDocumentStart   bool                   `mapstructure:"include_document_start"`
+	LineEnding             yamlfmt.LineBreakStyle `mapstructure:"line_ending"`
+	LineLength             int                    `mapstructure:"max_line_length"`
+	RetainLineBreaks       bool                   `mapstructure:"retain_line_breaks"`
+	RetainLineBreaksSingle bool                   `mapstructure:"retain_line_breaks_single"`
+	DisallowAnchors        bool                   `mapstructure:"disallow_anchors"`
+	ScanFoldedAsLiteral    bool                   `mapstructure:"scan_folded_as_literal"`
+	IndentlessArrays       bool                   `mapstructure:"indentless_arrays"`
+	DropMergeTag           bool                   `mapstructure:"drop_merge_tag"`
+	PadLineComments        int                    `mapstructure:"pad_line_comments"`
 }
 
 func DefaultConfig() *Config {

--- a/formatters/basic/features.go
+++ b/formatters/basic/features.go
@@ -23,12 +23,12 @@ import (
 
 func ConfigureFeaturesFromConfig(config *Config) yamlfmt.FeatureList {
 	features := []yamlfmt.Feature{}
-	if config.RetainLineBreaks {
+	if config.RetainLineBreaks || config.RetainLineBreaksSingle {
 		lineSep, err := config.LineEnding.Separator()
 		if err != nil {
 			lineSep = "\n"
 		}
-		featLineBreak := hotfix.MakeFeatureRetainLineBreak(lineSep)
+		featLineBreak := hotfix.MakeFeatureRetainLineBreak(lineSep, config.RetainLineBreaksSingle)
 		features = append(features, featLineBreak)
 	}
 	return features

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -125,12 +125,13 @@ func TestEmojiSupport(t *testing.T) {
 
 func TestRetainLineBreaks(t *testing.T) {
 	testCases := []struct {
-		desc   string
+		name   string
 		input  string
 		expect string
+		single bool
 	}{
 		{
-			desc: "basic",
+			name: "basic",
 			input: `a:  1
 
 b: 2`,
@@ -140,7 +141,7 @@ b: 2
 `,
 		},
 		{
-			desc: "multi-doc",
+			name: "multi-doc",
 			input: `a:  1
 
 # tail comment
@@ -154,7 +155,7 @@ b: 2
 `,
 		},
 		{
-			desc: "literal string",
+			name: "literal string",
 			input: `a:  1
 
 shell: |
@@ -175,7 +176,7 @@ shell: |
 `,
 		},
 		{
-			desc: "multi level nested literal string",
+			name: "multi level nested literal string",
 			input: `a:  1
 x:
   y:
@@ -194,18 +195,39 @@ x:
       echo "hello, world"
 `,
 		},
+		{
+			name:   "retain single line break",
+			single: true,
+			input: `a: 1
+
+
+
+
+b: 2
+
+
+c: 3
+`,
+			expect: `a: 1
+
+b: 2
+
+c: 3
+`,
+		},
 	}
-	config := basic.DefaultConfig()
-	config.RetainLineBreaks = true
-	f := newFormatter(config)
-	for _, c := range testCases {
-		t.Run(c.desc, func(t *testing.T) {
-			got, err := f.Format([]byte(c.input))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := basic.DefaultConfig()
+			config.RetainLineBreaks = true
+			config.RetainLineBreaksSingle = tc.single
+			f := newFormatter(config)
+			got, err := f.Format([]byte(tc.input))
 			if err != nil {
 				t.Fatalf("expected formatting to pass, returned error: %v", err)
 			}
-			if string(got) != c.expect {
-				t.Fatalf("didn't retain line breaks\nresult: %v\nexpect %s", string(got), c.expect)
+			if string(got) != tc.expect {
+				t.Fatalf("didn't retain line breaks\nresult: %v\nexpect %s", string(got), tc.expect)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #152 

This PR adds a new formatter config option `retain_line_breaks_single` which will retain line breaks, but in large groups of line breaks only keep one at a time. So this:
```yaml
a: 1



b: 1
```
Becomes:
```yaml
a: 1

b: 1
```