### PR TITLE
Fix: global_conf not taking priority

### DIFF
--- a/cmd/yamlfmt/config.go
+++ b/cmd/yamlfmt/config.go
@@ -109,18 +109,19 @@ func getConfigPath() (string, error) {
 
 func getConfigPathFromFlag() (string, error) {
 	// If there is a path specified in the conf flag, that takes precedence
-	configPath := *flagConf
-	if configPath == "" {
-		logger.Debug(logger.DebugCodeConfig, "No config path specified in -conf")
-		return configPath, errNoConfFlag
-	}
-	// Then we check if we want the global config
 	if *flagGlobalConf {
 		logger.Debug(logger.DebugCodeConfig, "Using -global_conf flag")
 		return getConfigPathFromXdgConfigHome()
 	}
-	logger.Debug(logger.DebugCodeConfig, "Using config path %s from -conf flag", configPath)
-	return configPath, validatePath(configPath)
+	
+	configPath := *flagConf
+	if configPath != "" {
+		logger.Debug(logger.DebugCodeConfig, "Using config path %s from -conf flag", configPath)
+		return configPath, validatePath(configPath)
+	}
+	// Then we check if we want the global config
+	logger.Debug(logger.DebugCodeConfig, "No config path specified in -conf")
+	return configPath, errNoConfFlag
 }
 
 // This function searches up the directory tree until it finds

--- a/cmd/yamlfmt/config.go
+++ b/cmd/yamlfmt/config.go
@@ -108,18 +108,18 @@ func getConfigPath() (string, error) {
 }
 
 func getConfigPathFromFlag() (string, error) {
-	// If there is a path specified in the conf flag, that takes precedence
+	// First check if the global configuration was explicitly requested as that takes precedence.
 	if *flagGlobalConf {
 		logger.Debug(logger.DebugCodeConfig, "Using -global_conf flag")
 		return getConfigPathFromXdgConfigHome()
 	}
-	
+	// If the global config wasn't explicitly requested, check if there was a specific configuration path supplied.
 	configPath := *flagConf
 	if configPath != "" {
 		logger.Debug(logger.DebugCodeConfig, "Using config path %s from -conf flag", configPath)
 		return configPath, validatePath(configPath)
 	}
-	// Then we check if we want the global config
+	
 	logger.Debug(logger.DebugCodeConfig, "No config path specified in -conf")
 	return configPath, errNoConfFlag
 }


### PR DESCRIPTION
Based on the line in the docs:
> If the flag -global_conf is passed, all other steps will be circumvented and the config file will be discovered from the system config directory

This logic was backwards. Current functionality searches for the `-conf` path and when one isn't passed (like when using `-global_conf` only) it immediately returns and does not search for the global_conf. This causes the config file from the current working directory to be picked up _before_ the global conf does even when the flag is set explicitly.

Examples A, C, D are given so that existing & future functionality can be shown to be the same. However Example B is the current and fixed issue.


## Functionality comparisons:

### Scenario A:
- Config exists in local directory
- Global config exists
- No flags passed in

Expected result: Uses local config
Existing Result: Uses local config
New Result: Uses local config

#### Existing
```
❯ yamlfmt -debug config
[DEBUG]: No config path specified in -conf
[DEBUG]: Found config at /Users/kilian/test/current-dir/.yamlfmt
[DEBUG]: Found config at /Users/kilian/test/current-dir/.yamlfmt
```

#### New
```
❯ yamlfmt -debug config
[DEBUG]: No config path specified in -conf
[DEBUG]: Found config at /Users/kilian/test/current-dir/.yamlfmt
[DEBUG]: Found config at /Users/kilian/test/current-dir/.yamlfmt
```

### Scenario B:
- Config exists in local directory
- Global config exists
- -global_conf passed in

Expected Result: Uses global config
Existing Result: Uses local config
**New Result: Uses global config**

#### Existing
```
❯ yamlfmt -debug config -global_conf
[DEBUG]: No config path specified in -conf
[DEBUG]: Found config at /Users/kilian/test/current-dir/.yamlfmt
[DEBUG]: Found config at /Users/kilian/test/current-dir/.yamlfmt
```

#### New
```
❯ yamlfmt -debug config -global_conf
[DEBUG]: Using -global_conf flag
[DEBUG]: Found config at /Users/kilian/.config/yamlfmt/.yamlfmt
```

### Scenario C:
- Config exists in local directory
- Global config exists
- -conf flag passed in

Expected Result: Uses -conf specified file
Existing Result: Uses -conf specified file
New Result: 

#### Existing
```
❯ yamlfmt -debug config -conf /Users/kilian/test2/yamlfmt.yaml
[DEBUG]: Using config path /Users/kilian/test2/yamlfmt.yaml from -conf flag
```

#### New
```
❯ yamlfmt -debug config -conf /Users/kilian/test2/yamlfmt.yaml
[DEBUG]: Using config path /Users/kilian/test2/yamlfmt.yaml from -conf flag
```

### Scenario D:
- Config exists in local directory
- Global config exists
- -global_conf & -conf are passed in

Expected Result: -global_conf takes precidence
Current Result: -global_conf takes precidence
New Result: -global_conf takes precidence

#### Existing
```
❯ yamlfmt -debug config -global_conf -conf /Users/kilian/test2/yamlfmt.yaml
[DEBUG]: Using -global_conf flag
[DEBUG]: Found config at /Users/kilian/.config/yamlfmt/.yamlfmt
```

#### New
```
❯ yamlfmt -debug config -global_conf -conf /Users/kilian/test2/yamlfmt.yaml
[DEBUG]: Using -global_conf flag
[DEBUG]: Found config at /Users/kilian/.config/yamlfmt/.yamlfmt
```