### PR TITLE
command: fix stdin operation output

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -158,7 +158,7 @@ func (c *Command) Run() error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(out)
+		fmt.Print(string(out))
 	}
 
 	return nil


### PR DESCRIPTION
When I added output format, I accidentally changed a string cast for the stdin operation's output which I should have left.

Will add an integration test to cover this but I'm getting this through first so I can patch release.