### PR TITLE
feat: fill version with git and ldflags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,6 @@ jobs:
     strategy:
       matrix:
         version: ['1.18']
-    env:
-      GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.builtBy=goreleaser'
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}'
 archives:
   - name_template: >-
       {{ .ProjectName }}_

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,8 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.builtBy=goreleaser'
 archives:
   - name_template: >-
       {{ .ProjectName }}_

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 .EXPORT_ALL_VARIABLES:
 
+VERSION  := $(shell git describe --abbrev=0 --tags | tr -d v)
+COMMIT := $(shell git rev-parse --short HEAD)
+LDFLAGS := -X 'main.version=$(VERSION)' \
+           -X 'main.commit=$(COMMIT)'
+
 .PHONY: build
 build:
-	go build -o dist/yamlfmt ./cmd/yamlfmt
+	go build -ldflags "$(LDFLAGS)" -o dist/yamlfmt ./cmd/yamlfmt
 
 .PHONY: test
 test:
@@ -43,7 +48,7 @@ endif
 
 .PHONY: install
 install:
-	go install ./cmd/yamlfmt
+	go install -ldflags "$(LDFLAGS)" ./cmd/yamlfmt
 
 .PHONY: install_tools
 install_tools:

--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -26,7 +26,10 @@ import (
 	"github.com/google/yamlfmt/internal/logger"
 )
 
-var version string = "0.12.0"
+var (
+	version = "dev"
+	commit  = "none"
+)
 
 func main() {
 	if err := run(); err != nil {
@@ -41,7 +44,7 @@ func run() error {
 	flag.Parse()
 
 	if *flagVersion {
-		fmt.Printf("%s\n", version)
+		fmt.Printf("yamlfmt %s (%s)\n", version, commit)
 		return nil
 	}
 


### PR DESCRIPTION
Suggestion
---

I want to resolve two things in this PR.

* Fill revision with git ref
* Prevent missing to bump the version string

Background
---

https://github.com/google/yamlfmt/releases/tag/v0.12.1

* >Known Issue: I was in a rush to get this out when I saw it and forgot to manually update the version string, so yamlfmt -version will print v0.12.0 for this version.
* https://github.com/google/yamlfmt/pull/175
* https://github.com/google/yamlfmt/pull/178

This is my omitted part in https://github.com/google/yamlfmt/pull/117 🙇‍♂️ 

Example
---

### Before

goreleaser

```console
> goreleaser build --single-target --snapshot --clean
> ./dist/yamlfmt_linux_amd64_v1/yamlfmt --version
0.12.2-next
```

go build / go install

```console
> make build
> ./dist/yamlfmt -version
0.12.0
```

### After

goreleaser

```console
> goreleaser build --single-target --snapshot --clean
> ./dist/yamlfmt_linux_amd64_v1/yamlfmt -version
yamlfmt 0.12.2-next (1a88c3d)
```

go build / go install

```console
> make build
> ./dist/yamlfmt -version
yamlfmt 0.12.1 (1a88c3d)
```