### PR TITLE
chore(ci): fix missing targets when using `go vet`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: go mod tidy
 
       - name: Go Vet
-        run: go vet
+        run: go vet ./...
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
Currently go vet does not check many files, for example `cmd/*.go`

```console
> go version
go version go1.22.2 linux/amd64

> go vet -json
# github.com/google/yamlfmt
{}
# github.com/google/yamlfmt_test
# [github.com/google/yamlfmt_test]
{}

> go vet -json ./...
# github.com/google/yamlfmt/internal/collections
{}
# github.com/google/yamlfmt/internal/assert
{}
# github.com/google/yamlfmt/internal/multilinediff
{}
# github.com/google/yamlfmt/internal/logger
{}
# github.com/google/yamlfmt/internal/collections_test
# [github.com/google/yamlfmt/internal/collections_test]
{}
# github.com/google/yamlfmt/internal/tempfile
{}
# github.com/google/yamlfmt/internal/assert_test
# [github.com/google/yamlfmt/internal/assert_test]
{}
# github.com/google/yamlfmt
{}
# github.com/google/yamlfmt/internal/hotfix
{}
# github.com/google/yamlfmt/engine
{}
# github.com/google/yamlfmt_test
# [github.com/google/yamlfmt_test]
{}
# github.com/google/yamlfmt/formatters/basic/anchors
{}
# github.com/google/yamlfmt/formatters/basic/anchors_test
# [github.com/google/yamlfmt/formatters/basic/anchors_test]
{}
# github.com/google/yamlfmt/command
{}
# github.com/google/yamlfmt/formatters/basic
{}
# github.com/google/yamlfmt/formatters/basic_test
# [github.com/google/yamlfmt/formatters/basic_test]
{}
# github.com/google/yamlfmt/cmd/yamlfmt
# [github.com/google/yamlfmt/cmd/yamlfmt]
{}
```