### PR TITLE
🐛 panic against empty file with eof_newline feature, resolves: #196

### DIFF
--- a/internal/features/eof_newline.go
+++ b/internal/features/eof_newline.go
@@ -28,7 +28,7 @@ func MakeFeatureEOFNewline(linebreakStr string) yamlfmt.Feature {
 func eofNewlineFeature(linebreakStr string) yamlfmt.FeatureFunc {
 	return func(content []byte) ([]byte, error) {
 		// This check works in both linebreak modes.
-		if content[len(content)-1] != '\n' {
+		if len(content) == 0 || content[len(content)-1] != '\n' {
 			linebreakBytes := []byte(linebreakStr)
 			content = append(content, linebreakBytes...)
 		}


### PR DESCRIPTION
This PR resolves #196.

YAMLfmt throws panic when linting an empty file with eof_newline feature on.
The problem is that `eofNewlineFeature` has out-of-range access when `content` is empty.
This PR fixes it and handles case when `content` is empty.

