### PR TITLE
ci: sign checksum file with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,13 +19,13 @@ on:
     tags:
       - "*"
 
+permissions:
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    strategy:
-      matrix:
-        version: ['1.18']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -34,11 +34,15 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.version }}
+          go-version: 1.18
           check-latest: true
           cache: true
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.0'
       - name: Build and package with GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
@@ -48,4 +52,6 @@ jobs:
         with:
           files: |
             dist/checksums.txt
+            dist/checksums.txt.pem
+            dist/checksums.txt.sig
             dist/*.tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -39,7 +41,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
@@ -47,4 +49,15 @@ changelog:
       - '^docs:'
       - '^test:'
       - '^ci:'
-
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This currently requires Go version 1.18 or greater.
 
 NOTE: Recommended setup if this is your first time installing Go would be in [this DigitalOcean blog post](https://www.digitalocean.com/community/tutorials/how-to-build-and-install-go-programs).
 
-You can also download the binary you want from releases. The binary is self-sufficient with no dependencies, and can simply be put somewhere on your PATH and run with the command `yamlfmt`.
+You can also download the binary you want from releases. The binary is self-sufficient with no dependencies, and can simply be put somewhere on your PATH and run with the command `yamlfmt`. Read more about verifying the authenticity of released artifacts [here](#verifying-release-artifacts).
 
 You can also install the command as a [pre-commit](https://pre-commit.com/) hook. See the [pre-commit hook](./docs/pre-commit.md) docs for instructions.
 
@@ -55,3 +55,41 @@ See the [doublestar](https://github.com/bmatcuk/doublestar) package for more inf
 
 The `yamlfmt` command can be configured through a yaml file called `.yamlfmt`. This file can live in your working directory, a path specified through a [CLI flag](./docs/command-usage.md#operation-flags), or in the standard global config path on your system (see docs for specifics).
 For in-depth configuration documentation see [Config](docs/config-file.md).
+
+## Verifying release artifacts
+
+In case you get the `yamlfmt` binary directly from a release, you may want to verify its authenticity. Checksums are applied to all released artifacts, and the resulting checksum file is signed using [cosign](https://docs.sigstore.dev/cosign/installation/).
+
+Steps to verify (replace `A.B.C` in the commands listed below with the version you want):
+
+1. Download the following files from the release:
+
+   ```text
+   curl -sfLO https://github.com/google/yamlfmt/releases/download/vA.B.C/checksums.txt
+   curl -sfLO https://github.com/google/yamlfmt/releases/download/vA.B.C/checksums.txt.pem
+   curl -sfLO https://github.com/google/yamlfmt/releases/download/vA.B.C/checksums.txt.sig
+   ```
+
+2. Verify the signature:
+
+   ```shell
+    cosign verify-blob checksums.txt \
+       --certificate checksums.txt.pem \
+       --signature checksums.txt.sig \
+       --certificate-identity-regexp 'https://github\.com/google/yamlfmt/\.github/workflows/.+' \
+       --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+   ```
+
+3. Download the compressed archive you want, and validate its checksum:
+
+   ```shell
+   curl -sfLO https://github.com/google/yamlfmt/releases/download/vA.B.C/yamlfmt_A.B.C_Linux_x86_64.tar.gz
+   sha256sum --ignore-missing -c checksums.txt
+   ```
+
+3. If checksum validation goes through, uncompress the archive:
+
+   ```shell
+   tar -xzf yamlfmt_A.B.C_Linux_x86_64.tar.gz
+   ./yamlfmt
+   ```

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 )
 
-require github.com/santhosh-tekuri/jsonschema/v4 v4.0.0 // indirect
+require github.com/santhosh-tekuri/jsonschema/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -14,13 +14,9 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/santhosh-tekuri/jsonschema/v4 v4.0.0 h1:5yvbsmEfOQE2+YuRudUhXPzMQK6P74AR3LafM5zrzf0=
 github.com/santhosh-tekuri/jsonschema/v4 v4.0.0/go.mod h1:P2UNYJ2xnL4zRyQ2obmD35HiejSJhHTKwMcckhPucG4=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
Hi. Thanks for maintaining `yamlfmt`!

I saw that the release artifacts aren't being signed. This PR adds the ability to sign the checksum file using [cosign keyless signing](https://docs.sigstore.dev/signing/signing_with_blobs). It's all done via goreleaser (which is also upgraded to [version 2](https://goreleaser.com/blog/goreleaser-v2/)).

**You can see this running in action [here](https://github.com/dhth/yamlfmt/pull/1).**

*Not sure if signing release assets was on your roadmap, but if it was, hopefully this helps :)*

---

I've also added instructions on how to verify the authenticity of the released assets to the README. Basically, the process looks like this (this is tweaked for my fork):

1. Download the following files from the release:

   ```text
   curl -sfLO https://github.com/dhth/yamlfmt/releases/download/v0.13.5/checksums.txt
   curl -sfLO https://github.com/dhth/yamlfmt/releases/download/v0.13.5/checksums.txt.pem
   curl -sfLO https://github.com/dhth/yamlfmt/releases/download/v0.13.5/checksums.txt.sig
   ```

2. Verify the signature:

   ```shell
    cosign verify-blob checksums.txt \
       --certificate checksums.txt.pem \
       --signature checksums.txt.sig \
       --certificate-identity-regexp 'https://github\.com/dhth/yamlfmt/\.github/workflows/.+' \
       --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
   ```

3. Download the compressed archive you want, and validate its checksum:

   ```shell
   curl -sfLO https://github.com/dhth/yamlfmt/releases/download/v0.13.5/yamlfmt_0.13.5_Darwin_arm64.tar.gz
   sha256sum --ignore-missing -c checksums.txt
   ```

3. If checksum validation goes through, uncompress the archive:

   ```shell
   tar -xzf yamlfmt_0.13.5_Darwin_arm64.tar.gz
   ./yamlfmt
   ```