### PR TITLE
docs: change the language name from `Golang` to `Go`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Golang
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 - id: yamlfmt
-  name: yamlfmt 
-  description: This hook uses github.com/google/yamlfmt to format yaml files. Requires golang >1.18 to be installed.
+  name: yamlfmt
+  description: This hook uses github.com/google/yamlfmt to format yaml files. Requires Go >1.18 to be installed.
   entry: yamlfmt
   language: golang
   types: [yaml]

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -44,7 +44,7 @@ The command package defines the main command engine that `cmd/yamlfmt` uses. It 
 | `exclude`                | []string            | []            | The paths for the command to exclude from formatting. See [Specifying Paths][] for more details. |
 | `gitignore_excludes`     | bool                | false         | Use gitignore files for exclude paths. This is in addition to the patterns from the `exclude` option. |
 | `gitignore_path`         | string              | `.gitignore`  | The path to the gitignore file to use. |
-| `regex_exclude`          | []string            | []            | Regex patterns to match file contents for, if the file content matches the regex the file will be excluded. Use [Golang regexes](https://regex101.com/). |
+| `regex_exclude`          | []string            | []            | Regex patterns to match file contents for, if the file content matches the regex the file will be excluded. Use [Go regexes](https://regex101.com/). |
 | `extensions`             | []string            | []            | The extensions to use for standard mode path collection. See [Specifying Paths][] for more details. |
 | `formatter`              | map[string]any      | `type: basic` | Formatter settings. See [Formatter](#formatter) for more details. |
 | `output_format`          | `default` or `line` | `default`     | The output format to use. See [Output docs](./output.md) for more details. |

--- a/schema.json
+++ b/schema.json
@@ -56,7 +56,7 @@
         "type": "string"
       },
       "default": [],
-      "description": "Regex patterns to match file contents for, if the file content matches the regex the file will be excluded. Use Golang regexes."
+      "description": "Regex patterns to match file contents for, if the file content matches the regex the file will be excluded. Use Go regexes."
     },
     "extensions": {
       "type": "array",


### PR DESCRIPTION
According to the article https://go.dev/doc/faq#go_or_golang:

> The language is called Go. The “golang” moniker arose because the web site was originally golang.org. (There was no .dev domain then.) Many use the golang name, though, and it is handy as a label. For instance, the social media tag for the language is “#golang”. The language’s name is just plain Go, regardless.