### PR TITLE
fix typos in test names

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -24,7 +24,7 @@ import (
 
 // This test asserts the proper behaviour for `line_ending` settings specified
 // in formatter settings overriding the global configuration.
-func TestLineEndingFormatterVsGloabl(t *testing.T) {
+func TestLineEndingFormatterVsGlobal(t *testing.T) {
 	c := &Command{
 		Config: &Config{
 			LineEnding: "lf",

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -25,7 +25,7 @@ var (
 	NilErrMessage = "expected no error, got error:\n%v"
 
 	// The failure format string if the err is nil.
-	NotNilErrMesage = "expected an error, got nil"
+	NotNilErrMessage = "expected an error, got nil"
 
 	// The failure format string for slices being different sizes. Formatted with `expected` then `got`.
 	SliceSizeMessage = "slices were different sizes.\nexpected len:%d\n     got len:%d\n"
@@ -69,16 +69,16 @@ func DereferenceEqual[T comparable](t TestingT, expected *T, got *T) {
 	DereferenceEqualMsg(t, expected, got, DereferenceEqualErrMsg, EqualMessage)
 }
 
-// Assert that that `err` is nil. Uses `assert.NilErrMessage`.
+// Assert that `err` is nil. Uses `assert.NilErrMessage`.
 func NilErr(t TestingT, err error) {
 	t.Helper()
 	Assert(t, err == nil, NilErrMessage, err)
 }
 
-// Assert that that `err` is not nil. Uses `assert.NotNillErrMesage`.
+// Assert that `err` is not nil. Uses `assert.NotNillErrMessage`.
 func NotNilErr(t TestingT, err error) {
 	t.Helper()
-	Assert(t, err != nil, NotNilErrMesage)
+	Assert(t, err != nil, NotNilErrMessage)
 }
 
 // Assert that slices `got` and `expected` are equal. Will produce a

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -75,7 +75,7 @@ func NilErr(t TestingT, err error) {
 	Assert(t, err == nil, NilErrMessage, err)
 }
 
-// Assert that `err` is not nil. Uses `assert.NotNillErrMessage`.
+// Assert that `err` is not nil. Uses `assert.NotNilErrMessage`.
 func NotNilErr(t TestingT, err error) {
 	t.Helper()
 	Assert(t, err != nil, NotNilErrMessage)

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -108,7 +108,7 @@ func TestDereferenceEqualErr(t *testing.T) {
 	}
 }
 
-func TestDerefenceEqualFail(t *testing.T) {
+func TestDereferenceEqualFail(t *testing.T) {
 	testInstance := newTMock()
 	type x struct {
 		num int


### PR DESCRIPTION
The PR corrects grammar mistakes in tests.