### PR TITLE
add array indent functionality

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -86,6 +86,8 @@ The basic formatter is a barebones formatter that simply takes the data provided
 | `trim_trailing_whitespace`  | bool           | false   | Trim trailing whitespace from lines. |
 | `eof_newline`               | bool           | false   | Always add a newline at end of file. Useful in the scenario where `retain_line_breaks` is disabled but the trailing newline is still needed. |
 | `strip_directives`          | bool           | false   | [YAML Directives](https://yaml.org/spec/1.2.2/#3234-directives) are not supported by this formatter. This feature will attempt to strip the directives before formatting and put them back. [Use this feature at your own risk.](#strip_directives) |
+| `array_indent`              | int            | = indent | Set a different indentation level for block sequences specifically. |
+| `indent_root_array`         | int            | false   | Tells the formatter to indent an array that is at the lowest indentation level of the document. |
 
 ## Additional Notes
 

--- a/formatters/basic/config.go
+++ b/formatters/basic/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	TrimTrailingWhitespace bool                   `mapstructure:"trim_trailing_whitespace"`
 	EOFNewline             bool                   `mapstructure:"eof_newline"`
 	StripDirectives        bool                   `mapstructure:"strip_directives"`
+	ArrayIndent            int                    `mapstructure:"array_indent"`
+	IndentRootArray        bool                   `mapstructure:"indent_root_array"`
 }
 
 func DefaultConfig() *Config {

--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -114,6 +114,11 @@ func (f *BasicFormatter) getNewEncoder(buf *bytes.Buffer) *yaml.Encoder {
 	e.SetDropMergeTag(f.Config.DropMergeTag)
 	e.SetPadLineComments(f.Config.PadLineComments)
 
+	if f.Config.ArrayIndent > 0 {
+		e.SetArrayIndent(f.Config.ArrayIndent)
+	}
+	e.SetIndentRootArray(f.Config.IndentRootArray)
+
 	return e
 }
 

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -363,3 +363,41 @@ func TestStripDirectives(t *testing.T) {
 	_, err := f.Format([]byte(yml))
 	assert.NilErr(t, err)
 }
+
+func TestArrayIndent(t *testing.T) {
+	config := basic.DefaultConfig()
+	config.ArrayIndent = 1
+	f := newFormatter(config)
+
+	yml := `a:
+  - 1
+  - 2
+`
+	expectedYml := `a:
+ - 1
+ - 2
+`
+
+	result, err := f.Format([]byte(yml))
+	assert.NilErr(t, err)
+	resultStr := string(result)
+	if resultStr != expectedYml {
+		t.Fatalf("expected: '%s', got: '%s'", expectedYml, result)
+	}
+}
+
+func TestIndentRootArray(t *testing.T) {
+	config := basic.DefaultConfig()
+	config.IndentRootArray = true
+	f := newFormatter(config)
+
+	yml := "- 1\n"
+	expectedYml := "  - 1\n"
+
+	result, err := f.Format([]byte(yml))
+	assert.NilErr(t, err)
+	resultStr := string(result)
+	if resultStr != expectedYml {
+		t.Fatalf("expected: '%s', got: '%s'", expectedYml, result)
+	}
+}

--- a/integrationtest/command/testdata/print_conf_file/stdout/stdout.txt
+++ b/integrationtest/command/testdata/print_conf_file/stdout/stdout.txt
@@ -13,11 +13,13 @@ match_type: doublestar
 output_format: default
 regex_exclude: []
 formatter:
+    array_indent: 0
     disallow_anchors: false
     drop_merge_tag: false
     eof_newline: false
     include_document_start: true
     indent: 2
+    indent_root_array: false
     indentless_arrays: false
     line_ending: crlf
     max_line_length: 0

--- a/integrationtest/command/testdata/print_conf_flags/stdout/stdout.txt
+++ b/integrationtest/command/testdata/print_conf_flags/stdout/stdout.txt
@@ -12,11 +12,13 @@ match_type: standard
 output_format: default
 regex_exclude: []
 formatter:
+    array_indent: 0
     disallow_anchors: false
     drop_merge_tag: false
     eof_newline: false
     include_document_start: false
     indent: 2
+    indent_root_array: false
     indentless_arrays: false
     line_ending: lf
     max_line_length: 0

--- a/integrationtest/command/testdata/print_conf_flags_and_file/stdout/stdout.txt
+++ b/integrationtest/command/testdata/print_conf_flags_and_file/stdout/stdout.txt
@@ -13,11 +13,13 @@ match_type: doublestar
 output_format: default
 regex_exclude: []
 formatter:
+    array_indent: 0
     disallow_anchors: false
     drop_merge_tag: false
     eof_newline: false
     include_document_start: true
     indent: 2
+    indent_root_array: false
     indentless_arrays: false
     line_ending: crlf
     max_line_length: 0


### PR DESCRIPTION
Fixes #237 

This PR makes use of the new functionality in the yaml library to allow alternate array indents and indenting the root array.