### PR TITLE
formatters/basic: fix just comments edge case

### DIFF
--- a/formatters/basic/formatter.go
+++ b/formatters/basic/formatter.go
@@ -64,6 +64,10 @@ func (f *BasicFormatter) Format(input []byte) ([]byte, error) {
 		documents = append(documents, docNode)
 	}
 
+	if len(documents) == 0 {
+		return input, nil
+	}
+
 	// Run all YAML features.
 	for _, d := range documents {
 		if err := f.YAMLFeatures.ApplyFeatures(d); err != nil {

--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -455,3 +455,17 @@ b:
 		t.Fatalf("expected: '%s', got: '%s'", expectedYml, result)
 	}
 }
+
+func TestJustComments(t *testing.T) {
+	config := basic.DefaultConfig()
+	f := newFormatter(config)
+
+	yml := `# hi`
+	expectedYml := `# hi`
+	result, err := f.Format([]byte(yml))
+	assert.NilErr(t, err)
+	resultStr := string(result)
+	if resultStr != expectedYml {
+		t.Fatalf("expected: '%s', got: '%s'", expectedYml, result)
+	}
+}


### PR DESCRIPTION
Fixes #254 

When `yaml.v3` parses a document that's just comments, it ends up parsing no actual nodes and thus loses the comment information. This will now be treated as an edge case and return the original content, in essence not modifying it if the yaml parsed successfully but no nodes are parsed out.