### PR TITLE
Remove trailing whitespace from merge aliases.

### DIFF
--- a/pkg/yaml/emitterc.go
+++ b/pkg/yaml/emitterc.go
@@ -888,7 +888,7 @@ func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 
 	switch event.typ {
 	case yaml_ALIAS_EVENT:
-		return yaml_emitter_emit_alias(emitter, event)
+		return yaml_emitter_emit_alias(emitter)
 	case yaml_SCALAR_EVENT:
 		return yaml_emitter_emit_scalar(emitter, event)
 	case yaml_SEQUENCE_START_EVENT:
@@ -902,11 +902,12 @@ func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 }
 
 // Expect ALIAS.
-func yaml_emitter_emit_alias(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+func yaml_emitter_emit_alias(emitter *yaml_emitter_t) bool {
 	if !yaml_emitter_process_anchor(emitter) {
 		return false
 	}
-	if emitter.correct_alias_keys && len(emitter.states) > 1 && emitter.states[len(emitter.states)-2] == yaml_EMIT_BLOCK_MAPPING_KEY_STATE {
+	if emitter.correct_alias_keys && emitter.simple_key_context &&
+		len(emitter.states) > 1 && emitter.states[len(emitter.states)-2] == yaml_EMIT_BLOCK_MAPPING_KEY_STATE {
 		if !put(emitter, ' ') {
 			return false
 		}

--- a/pkg/yaml/formattest/testcase.go
+++ b/pkg/yaml/formattest/testcase.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/yamlfmt/pkg/yaml"
 )
 
@@ -77,8 +78,9 @@ func (tc formatTestCase) Run(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if buf.String() != string(expected) {
-			t.Fatalf("expected:\n%s\nactual:\n%s", string(expected), buf.String())
+
+		if diff := cmp.Diff(string(expected), buf.String()); diff != "" {
+			t.Fatalf("Encode() result differs (-want/+got):\n%s", diff)
 		}
 	})
 }

--- a/pkg/yaml/formattest/testdata/alias_key/expected.yaml
+++ b/pkg/yaml/formattest/testdata/alias_key/expected.yaml
@@ -2,3 +2,7 @@ map_key: &anchor hello
 map:
     *anchor :
         key: value
+to_be_merged: &tbm
+    key1: value1
+merged_map:
+    !!merge <<: *tbm

--- a/pkg/yaml/formattest/testdata/alias_key/input.yaml
+++ b/pkg/yaml/formattest/testdata/alias_key/input.yaml
@@ -2,3 +2,8 @@ map_key: &anchor hello
 map:
     *anchor :
         key: value
+
+to_be_merged: &tbm
+    key1: value1
+merged_map:
+    <<: *tbm


### PR DESCRIPTION
PR #247 introduced a regression with YAML documents such as this:

```yaml
config: &shared
  key: value

instance:
  <<: *shared
```

Due to the "correct alias keys" setting, a extra space was emitted after `*shared`. This created trailing whitespace which many tools (rightly) complain about.

This change adds an extra condition to only emit the space in the "simple key" context. I'm not enough of a YAML expert to be sure this is the right thing to do, but it fixes my problem without failing any of the existing tests.
