### PR TITLE
cmd: print usage when supplied no config

### DIFF
--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -69,6 +69,12 @@ func run() error {
 		if err != nil {
 			return err
 		}
+	} else if len(os.Args) == 1 {
+		// If the user doesn't have a yamlfmt config and didn't provide
+		// any arguments, the command is destined to no-op. Provide the
+		// default help message to indicate proper usage.
+		flag.Usage()
+		return nil
 	}
 
 	commandConfig, err := makeCommandConfigFromData(configData)


### PR DESCRIPTION
Fixes #271 

If no config is supplied via file or arguments, print a usage message to indicate proper usage of the yamlfmt command.