### PR TITLE
pre-commit: don't pass filenames

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,5 +15,6 @@
 - id: yamlfmt
   name: yamlfmt
   description: This hook uses github.com/google/yamlfmt to format yaml files. Requires Go >1.18 to be installed.
-  entry: yamlfmt
+  entry: yamlfmt .
+  pass_filenames: false
   language: golang

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -4,12 +4,32 @@ Starting in v0.7.1, `yamlfmt` can be used as a hook for the popular [pre-commit]
 
 ```yaml
 - repo: https://github.com/google/yamlfmt
-  rev: v0.18.0
+  rev: v0.18.1
   hooks:
     - id: yamlfmt
 ```
 
-When running yamlfmt with the `pre-commit` hook, the only way to configure it is through a `.yamlfmt` configuration file in the root of the repo or a system wide config directory (see [Configuration File](./config-file.md) docs). 
+## Configuration
+
+The default `entry` for the hook is `yamlfmt .`. This is a reasonable default experience if you are not providing `yamlfmt` with a configuration. You can provide configuration either [through a file](./config-file.md) or [through the command line](./command-usage.md). This may require you to override the `entry`. For example, if you have a configuration file with the exact formatting experience you want (all the right files passed in, all the right formatter settings) then you may want to modify the entry to simply run the command with no arguments:
+
+```yaml
+- repo: https://github.com/google/yamlfmt
+  rev: v0.18.1
+  hooks:
+    - id: yamlfmt
+      entry: yamlfmt
+```
+
+You may also wish to provide all your configuration directly through the configuration flags like so:
+
+```yaml
+- repo: https://github.com/google/yamlfmt
+  rev: v0.18.1
+  hooks:
+    - id: yamlfmt
+      entry: yamlfmt -doublestar true **/*.{yaml,yml}
+```
 
 ## Use `yamlfmt` installed on the system instead of pre-commit building with Go
 
@@ -17,9 +37,22 @@ If you would prefer to manage your `yamlfmt` installation yourself, you can have
 
 ```yaml
 - repo: https://github.com/google/yamlfmt
-  rev: v0.18.0
+  rev: v0.18.1
   hooks:
     - id: yamlfmt
       language: system
 ```
 
+## Restore old behaviour
+
+In `v0.18.0` and `v0.18.1`, the experience was changed to what is documented here. What is documented here now is the intended experience. However, originally the hook was configured to only run on the `yaml` filetype, and all discovered files would be passed as a list of arguments to the command. This behaviour can be restored like so:
+
+```yaml
+- repo: https://github.com/google/yamlfmt
+  rev: v0.18.1
+  hooks:
+    - id: yamlfmt
+      entry: yamlfmt
+      files: [yaml]
+      pass_filenames: true
+```


### PR DESCRIPTION
Fixes #275 

By default, hooks will pass filenames to yamlfmt. On purpose, yamlfmt will handle this by accepting each file argument and passing it through the formatter with no guards. This is not a good default experience. This PR changes the hook to not pass filenames, and the default `entry` to be `yamlfmt .`. This should match the experience I thought the hook would be giving all along.