### PR TITLE
Change documentation for hook configuration from files to types

### DIFF
--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -53,6 +53,6 @@ In `v0.18.0` and `v0.18.1`, the experience was changed to what is documented her
   hooks:
     - id: yamlfmt
       entry: yamlfmt
-      files: [yaml]
+      types: [yaml]
       pass_filenames: true
 ```


### PR DESCRIPTION
Documentation was wrong, it should be `types: [yaml]` instead of `files: [yaml]`, otherwise pre-commit complaints.

```
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='https://github.com/google/yamlfmt')
==> At key: hooks
==> At Hook(id='yamlfmt')
==> At key: files
=====> Expected string got list
Check the log at .cache/pre-commit/pre-commit.log
```