### PR TITLE
pre-commit: restore original behaviour

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,6 +15,6 @@
 - id: yamlfmt
   name: yamlfmt
   description: This hook uses github.com/google/yamlfmt to format yaml files. Requires Go >1.18 to be installed.
-  entry: yamlfmt .
-  pass_filenames: false
+  entry: yamlfmt
   language: golang
+  types: [yaml]

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,35 +1,17 @@
 # pre-commit
 
+NOTE: https://github.com/google/yamlfmt/discussions/278 
+
 Starting in v0.7.1, `yamlfmt` can be used as a hook for the popular [pre-commit](https://pre-commit.com/) tool. To include a `yamlfmt` hook in your `pre-commit` config, add the following to the `repos` block in your `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/google/yamlfmt
-  rev: v0.18.1
+  rev: v0.19.0
   hooks:
     - id: yamlfmt
 ```
 
-## Configuration
-
-The default `entry` for the hook is `yamlfmt .`. This is a reasonable default experience if you are not providing `yamlfmt` with a configuration. You can provide configuration either [through a file](./config-file.md) or [through the command line](./command-usage.md). This may require you to override the `entry`. For example, if you have a configuration file with the exact formatting experience you want (all the right files passed in, all the right formatter settings) then you may want to modify the entry to simply run the command with no arguments:
-
-```yaml
-- repo: https://github.com/google/yamlfmt
-  rev: v0.18.1
-  hooks:
-    - id: yamlfmt
-      entry: yamlfmt
-```
-
-You may also wish to provide all your configuration directly through the configuration flags like so:
-
-```yaml
-- repo: https://github.com/google/yamlfmt
-  rev: v0.18.1
-  hooks:
-    - id: yamlfmt
-      entry: yamlfmt -doublestar true **/*.{yaml,yml}
-```
+When running yamlfmt with the `pre-commit` hook, the only way to configure it is through a `.yamlfmt` configuration file in the root of the repo or a system wide config directory (see [Configuration File](./config-file.md) docs). 
 
 ## Use `yamlfmt` installed on the system instead of pre-commit building with Go
 
@@ -37,22 +19,43 @@ If you would prefer to manage your `yamlfmt` installation yourself, you can have
 
 ```yaml
 - repo: https://github.com/google/yamlfmt
-  rev: v0.18.1
+  rev: v0.19.0
   hooks:
     - id: yamlfmt
       language: system
 ```
 
-## Restore old behaviour
+## Run `yamlfmt` on other filetypes
 
-In `v0.18.0` and `v0.18.1`, the experience was changed to what is documented here. What is documented here now is the intended experience. However, originally the hook was configured to only run on the `yaml` filetype, and all discovered files would be passed as a list of arguments to the command. This behaviour can be restored like so:
+By default, `yamlfmt` will run on all staged `.yaml` files. If you want to run on other filetypes, you can override the `types` configuration:
 
 ```yaml
 - repo: https://github.com/google/yamlfmt
-  rev: v0.18.1
+  rev: v0.19.0
   hooks:
     - id: yamlfmt
-      entry: yamlfmt
-      types: [yaml]
-      pass_filenames: true
+      types: [file]
+      files: <filepath regex>
 ```
+
+You can read more on file filtering in [the pre-commit docs for filtering files with `types`](https://pre-commit.com/#filtering-files-with-types).
+
+## Run `yamlfmt` with configuration
+
+If you are providing your own `yamlfmt` configuration file, the default hook experience is going to make `yamlfmt` behave in adverse ways. The experience the hook gives should be fine without a config file, or if your config file only provides `formatter` configuration, but if you provide path configuration there can be strange behaviour. One way around this is to modify the hook not to pass filenames as arguments:
+
+```yaml
+- repo: https://github.com/google/yamlfmt
+  rev: v0.19.0
+  hooks:
+    - id: yamlfmt
+      pass_filenames: false
+```
+
+This will make the entry simply `yamlfmt`, running the tool in the hook the same as the standard running pattern. It will cause the path configuration from the config file to be used.
+
+NOTE: `pre-commit` may create a `.cache` directory that could have `yaml` files in it. If using this mode, you will have to exclude the `.cache` directory using [the standard exclusion method based on your configured match type](./paths.md#include-and-exclude).
+
+## v0.18.0 series
+
+In v0.18.0, I attempted to make a breaking change to run the hook in a different way than I originally had it. This backfired and was broken in many ways. If you used this version, I am sorry for the confusion. v0.19.0 onward will have the original behaviour restored.


### PR DESCRIPTION
I give up. I shouldn't have messed with something I don't understand. This PR sets the hook back to the standard original operating method, and instead documents ways users can modify their hook configuration to run it in different ways. This is probably what I should have done originally.

I am never touching this hook again.