### PR TITLE
internal/multilinediff: change string concatenation to use strings.Repeat instead

### DIFF
--- a/internal/multilinediff/multilinediff.go
+++ b/internal/multilinediff/multilinediff.go
@@ -63,10 +63,7 @@ func (l diffLine) toLine(length int) string {
 
 	line += l.old
 
-	for i := 0; i < length-len(l.old); i++ {
-		line += " "
-	}
-
+	line += strings.Repeat(" ", length-len(l.old))
 	line += "  "
 
 	line += l.new


### PR DESCRIPTION
Fix for issue #283

This should guarantee exactly the same behavior but avoids edge case performance issues. I outlined few other suggestions in the task