### PR TITLE
[yamlfmt] Change FileDiff to use bytes by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,17 +26,17 @@ YAMLFMT_BIN ?= $(shell pwd)/dist/yamlfmt
 .PHONY: integrationtest
 integrationtest:
 	$(MAKE) build
-	go test -v -tags=integration_test ./integrationtest/command
+	go test -tags=integration_test -run=$(TESTNAME) ./integrationtest/command
 
 .PHONY: integrationtest_v
 integrationtest_v:
 	$(MAKE) build
-	go test -v -tags=integration_test ./integrationtest/command
+	go test -v -tags=integration_test -run=$(TESTNAME) ./integrationtest/command
 
 .PHONY: integrationtest_stdout
 integrationtest_stdout:
 	$(MAKE) build
-	go test -v -tags=integration_test ./integrationtest/command -stdout
+	go test -v -tags=integration_test -run=$(TESTNAME) ./integrationtest/command -stdout
 
 .PHONY: integrationtest_update
 integrationtest_update:

--- a/command/command.go
+++ b/command/command.go
@@ -137,7 +137,7 @@ func (c *Command) Run() error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(out))
+		fmt.Printf("%s", out)
 	case yamlfmt.OperationPrintConfig:
 		commandConfig := map[string]any{}
 		err = mapstructure.Decode(c.Config, &commandConfig)
@@ -149,7 +149,7 @@ func (c *Command) Run() error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(out))
+		fmt.Printf("%s", out)
 
 		formatterConfigMap, err := formatter.ConfigMap()
 		if err != nil {
@@ -161,7 +161,7 @@ func (c *Command) Run() error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(out))
+		fmt.Printf("%s", out)
 	}
 
 	return nil

--- a/engine/consecutive_engine.go
+++ b/engine/consecutive_engine.go
@@ -113,8 +113,8 @@ func (e *ConsecutiveEngine) formatFileContent(path string) (*yamlfmt.FileDiff, e
 	return &yamlfmt.FileDiff{
 		Path: path,
 		Diff: &yamlfmt.FormatDiff{
-			Original:  string(content),
-			Formatted: string(formatted),
+			Original:  content,
+			Formatted: formatted,
 			LineSep:   e.LineSepCharacter,
 		},
 	}, nil

--- a/internal/gitlab/codequality.go
+++ b/internal/gitlab/codequality.go
@@ -62,7 +62,7 @@ func NewCodeQuality(diff yamlfmt.FileDiff) (CodeQuality, bool) {
 func fingerprint(diff yamlfmt.FileDiff) string {
 	hash := sha256.New()
 
-	fmt.Fprint(hash, diff.Diff.Original)
+	fmt.Fprint(hash, diff.Diff.GetOriginal())
 
 	return fmt.Sprintf("%x", hash.Sum(nil)) //nolint:perfsprint
 }

--- a/internal/gitlab/codequality_test.go
+++ b/internal/gitlab/codequality_test.go
@@ -37,8 +37,8 @@ func TestCodeQuality(t *testing.T) {
 			diff: yamlfmt.FileDiff{
 				Path: "testcase/no_diff.yaml",
 				Diff: &yamlfmt.FormatDiff{
-					Original:  "a: b",
-					Formatted: "a: b",
+					Original:  []byte("a: b"),
+					Formatted: []byte("a: b"),
 				},
 			},
 			wantOK: false,
@@ -48,8 +48,8 @@ func TestCodeQuality(t *testing.T) {
 			diff: yamlfmt.FileDiff{
 				Path: "testcase/with_diff.yaml",
 				Diff: &yamlfmt.FormatDiff{
-					Original:  "a:   b",
-					Formatted: "a: b",
+					Original:  []byte("a:   b"),
+					Formatted: []byte("a: b"),
 				},
 			},
 			wantOK: true,


### PR DESCRIPTION
Fixes #292 

This PR adjusts `FileDiff.Original` and `FileDiff.Formatted` to use byte slice by default, and only do a string cast when requested. This path allows for scenarios where no diff comparison is done to avoid extra allocations.

While it's fairly inconsequential, I also changed some spots where I printed a casted byte array to use `Printf` instead as it saves an allocation. Those were not hot paths (run once at the end) but I decided to change them anyway since I'm here anyway.