### PR TITLE
[command] Fix /dev/stdin arg handling

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -80,18 +80,6 @@ func (c *Command) Run() error {
 		OutputFormat:     c.Config.OutputFormat,
 	}
 
-	collectedPaths, err := c.collectPaths()
-	if err != nil {
-		return err
-	}
-	if c.Config.GitignoreExcludes {
-		newPaths, err := yamlfmt.ExcludeWithGitignore(c.Config.GitignorePath, collectedPaths)
-		if err != nil {
-			return err
-		}
-		collectedPaths = newPaths
-	}
-
 	var paths []string
 	// If the operation is stdin, skip path analysis. You can only
 	// read from /dev/stdin once, so we don't want to read it
@@ -99,6 +87,17 @@ func (c *Command) Run() error {
 	if c.Operation == yamlfmt.OperationStdin {
 		paths = []string{}
 	} else {
+		collectedPaths, err := c.collectPaths()
+		if err != nil {
+			return err
+		}
+		if c.Config.GitignoreExcludes {
+			newPaths, err := yamlfmt.ExcludeWithGitignore(c.Config.GitignorePath, collectedPaths)
+			if err != nil {
+				return err
+			}
+			collectedPaths = newPaths
+		}
 		paths, err = c.analyzePaths(collectedPaths)
 		if err != nil {
 			fmt.Printf("path analysis found the following errors:\n%v", err)


### PR DESCRIPTION
Fixes #291 

When I added support for excluding files from formatting via metadata comments, I inadvertently broke `/dev/stdin` handling because yamlfmt would end up reading `/dev/stdin` to check file contents for metadata. Since you can only read `/dev/stdin` once, this would cause it to be empty when it actually goes to read it for formatting.