### PR TITLE
[ci] Update Go matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.25
           cache: true
 
       - name: Install tools
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22', '1.23', '1.24' ]
+        go: [ '1.23', '1.24', '1.25' ]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Sticking to the plan of testing current and 2 versions back for Go, this PR updates the matrix to the current status for Go versions.