### PR TITLE
fix: fix config not searched at root of filesystem

### DIFF
--- a/cmd/yamlfmt/config.go
+++ b/cmd/yamlfmt/config.go
@@ -154,13 +154,17 @@ func getConfigPathFromDirTree() (string, error) {
 		return "", err
 	}
 	dir := absPath
-	for dir != filepath.Dir(dir) {
+	for true {
 		configPath, err := getConfigPathFromDir(dir)
 		if err == nil {
 			logger.Debug(logger.DebugCodeConfig, "Found config at %s", configPath)
 			return configPath, nil
 		}
+		previousDir := dir
 		dir = filepath.Dir(dir)
+		if dir == previousDir {
+			break
+		}
 	}
 	return "", errConfPathNotExist
 }


### PR DESCRIPTION
This pull request fixes a problem with the current way to find the config. Currently the config will be searched up to the root but excluding it, even if the working directory is the root. This means a file at `/yamlfmt.yaml` will never be considered as config file. This is especially noticeable in container images where the working directory is either not known during the build of the image (in which the config will be added) or the config should only be a fallback in case the mounted working directory itself does not contain one. Using the `$XDG_CONFIG_HOME` wouldn't be a suitable solution, as the container may not be run as the user it has been configured with during the build of the image.