### PR TITLE
Fix superfluous comma in flow style mappings

### DIFF
--- a/formatters/basic/formatter_test.go
+++ b/formatters/basic/formatter_test.go
@@ -56,6 +56,21 @@ b:`,
 a:`,
 		},
 		{
+			// Regression test for https://github.com/google/yamlfmt/issues/110
+			// A blank line below a flow mapping sequence item (via retain_line_breaks)
+			// used to emit a superfluous trailing comma before the closing brace.
+			name: "no superfluous comma in flow style",
+			config: map[string]any{
+				"include_document_start": true,
+				"retain_line_breaks":     true,
+				// DefaultConfig picks CRLF on Windows; pin LF so the
+				// expected output is identical across platforms.
+				"line_ending": "lf",
+			},
+			input:  "---\n- {foo: bar}\n\n",
+			expect: "---\n- {foo: bar}\n\n",
+		},
+		{
 			name: "crlf line ending",
 			config: map[string]any{
 				"line_ending": "crlf",

--- a/pkg/yaml/emitterc.go
+++ b/pkg/yaml/emitterc.go
@@ -650,7 +650,7 @@ func yaml_emitter_emit_flow_mapping_key(emitter *yaml_emitter_t, event *yaml_eve
 	}
 
 	if event.typ == yaml_MAPPING_END_EVENT {
-		if (emitter.canonical || len(emitter.head_comment)+len(emitter.foot_comment)+len(emitter.tail_comment) > 0) && !first && !trail {
+		if emitter.canonical && !first && !trail {
 			if !yaml_emitter_write_indicator(emitter, []byte{','}, false, false, false) {
 				return false
 			}


### PR DESCRIPTION
## Summary

Fixes #110 — a flow-style mapping that carries a comment (e.g. a comment line below a flow mapping sequence item, which `retain_line_breaks` injects) was emitted with a superfluous trailing comma: `- {foo: bar,}`.

The flow-mapping `MAPPING_END` branch in `yaml_emitter_emit_flow_mapping_key` wrote a separator comma whenever any comment buffer was non-empty (`!first && !trail`). Comments on/below a flow mapping attach to the mapping node and arrive with the `FLOW_MAPPING_END` event, so that condition produced a comma before the closing brace even though no separator was needed.

Interior flow-map comments always flow through the TRAIL path (`yaml_emitter_emit_flow_mapping_value`), so a comma is never legitimately required at `MAPPING_END`. This change aligns the flow-mapping branch with the flow-sequence END branch, which already writes the comma only in canonical mode.

```diff
- if (emitter.canonical || len(emitter.head_comment)+len(emitter.foot_comment)+len(emitter.tail_comment) > 0) && !first && !trail {
+ if emitter.canonical && !first && !trail {
```

## Test plan

Added a regression case to `TestFormatter` using the exact reporter scenario (`include_document_start` + `retain_line_breaks`, blank line below `- {foo: bar}`):

- **Before fix:** output is `---\n- {foo: bar,}\n` → test fails
- **After fix:** output is `---\n- {foo: bar}\n` → test passes

Verified the full `go test ./...` failure set is identical with/without the change (no regressions), and `gofmt`/`go vet` are clean.

## Notes

- This bug is inherited from upstream yaml.v3's emitter logic (identical condition in `go.yaml.in/yaml/v3`), not introduced by the yamlfmt fork.
- AI assistance: this patch was developed with the aid of an AI coding assistant (Claude Code); root cause, fix, and test were reviewed and verified manually.